### PR TITLE
Fixed issue #131

### DIFF
--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -358,6 +358,12 @@
 
 (defun kubernetes-overview--poll (&optional verbose)
   (let ((sections (kubernetes-state-overview-sections (kubernetes-state))))
+    (when (member 'overview sections)
+      (kubernetes-pods-refresh verbose)
+      (kubernetes-configmaps-refresh verbose)
+      (kubernetes-secrets-refresh verbose)
+      (kubernetes-statefulsets-refresh verbose)
+      (kubernetes-deployments-refresh verbose))
     (when (member 'configmaps sections)
       (kubernetes-configmaps-refresh verbose))
     (when (member 'context sections)


### PR DESCRIPTION
Today overview is an aggregated view comprising of `statefulsets` and
`deployments`. Handled this special case in
`kubernetes-overview--poll` function.

Suggested by: @egh