### PR TITLE
Modified format lines to have consistent view

### DIFF
--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -37,7 +37,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Data
                          (propertize (format (pop list-fmt) (seq-length data)) 'face 'magit-dimmed)

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -65,7 +65,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Replicas (current/desired)
                          (let ((next (pop list-fmt))

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -36,10 +36,10 @@
            ingress)
           (line `(line ,(concat
                          ;; Name
-                         (format "%-45s " (kubernetes-utils-ellipsize name 45))
+                         (format "%-45s " (kubernetes-utils-ellipsize name 43))
 
                          ;; Hosts
-                         (format "%-25s " (--mapcat (alist-get 'host it) ingress-rules))
+                         (format "%-25s " (kubernetes-utils-ellipsize (--mapcat (alist-get 'host it) ingress-rules) 23))
 
                          ;; Address
                           (format "%20s "

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -66,7 +66,7 @@
           (list-fmt (split-string fmt))
           (line (concat
                  ;; Name
-                 (let ((name-str (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))))
+                 (let ((name-str (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))))
                    (cond
                     ((and completion-time (< 0 successful))
                      (propertize name-str 'face 'magit-dimmed))

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -50,7 +50,7 @@
           (str
            (concat
             ;; Name
-            (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+            (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
             " "
             ;; Status
             (let ((s (kubernetes-utils-ellipsize type 10)))

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -68,7 +68,7 @@
           (str
            (concat
             ;; Name
-            (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+            (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
             " "
             ;; Status
             (let ((s (format (pop list-fmt) (kubernetes-utils-ellipsize pod-state 10))))

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -35,7 +35,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Data
                          (propertize (format (pop list-fmt) (seq-length data)) 'face 'magit-dimmed)

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -18,7 +18,7 @@
 ;; Components
 
 (defconst kubernetes-services--column-heading
-  ["%-30s %15s %15s %6s" "Name|Internal IP|External IP|Age"])
+  ["%-45s %15s %15s %6s" "Name|Internal IP|External IP|Age"])
 
 (kubernetes-ast-define-component service-details (service)
   (-let ((detail
@@ -66,7 +66,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 30))
+                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Internal IP
                          (propertize (format (pop list-fmt) internal-ip) 'face 'magit-dimmed)

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -65,7 +65,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 45))
+                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Replicas (current/desired)
                          (let ((str (format "%s/%s" current desired))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -63,7 +63,7 @@
 
 (defun kubernetes-utils-ellipsize (s threshold)
   (if (> (length s) threshold)
-      (concat (substring s 0 (1- threshold)) "…")
+      (concat (substring s 0 (1- threshold)) "...")
     s))
 
 (defun kubernetes-utils-parse-utc-timestamp (timestamp)

--- a/test/kubernetes-services-test.el
+++ b/test/kubernetes-services-test.el
@@ -19,7 +19,7 @@
   (s-trim-left "
 
 Services
-  Name                               Internal IP     External IP    Age
+  Name                                              Internal IP     External IP    Age
   Fetching...
 
 "))
@@ -62,8 +62,8 @@ Services (0)
   (s-trim-left "
 
 Services (2)
-  Name                               Internal IP     External IP    Age
-  example-svc-1                      192.168.0.0     192.168.0.0     4d
+  Name                                              Internal IP     External IP    Age
+  example-svc-1                                     192.168.0.0     192.168.0.0     4d
     Selector:      example-pod-v1
     Label:         example-svc-1
     Namespace:     example
@@ -72,7 +72,7 @@ Services (2)
     External IPs:  192.168.0.0
     Ports:         80/TCP
 
-  example-svc-2                      192.168.0.0                    19d
+  example-svc-2                                     192.168.0.0                    19d
     Selector:      example-pod-v1
     Label:         example-svc-2
     Namespace:     example


### PR DESCRIPTION
`kubernetes-utils-ellipsize` function was using a special character
which was causing formatting issues. Replaced special character with
ASCII `...`.

Above change was not alone enough. Passed correct threshold value to
`kubernetes-utils-ellipsize`.