### PR TITLE
Fixed #161: Unbind `M-w` in kubernetes-logs-mode

### DIFF
--- a/kubernetes-logs.el
+++ b/kubernetes-logs.el
@@ -101,6 +101,7 @@ STATE is the current application state"
     (define-key keymap (kbd "n") #'kubernetes-logs-forward-line)
     (define-key keymap (kbd "p") #'kubernetes-logs-previous-line)
     (define-key keymap (kbd "RET") #'kubernetes-logs-inspect-line)
+    (define-key keymap (kbd "M-w") nil)
     keymap)
   "Keymap for `kubernetes-logs-mode'.")
 


### PR DESCRIPTION
`M-w` is bound to `kubernetes-copy-thing-at-point` in kubernetes major
mode. Since there is no specific behavior for this key in log buffer
it is better to fall back to global binding for the same.