### PR TITLE
Basic tramp support

### DIFF
--- a/kubernetes-evil.el
+++ b/kubernetes-evil.el
@@ -64,6 +64,7 @@
   (kbd "d") #'kubernetes-describe-popup
   (kbd "D") #'kubernetes-mark-for-delete
   (kbd "e") #'kubernetes-exec-popup
+  (kbd "f") #'kubernetes-file-popup
   (kbd "u") #'kubernetes-unmark
   (kbd "U") #'kubernetes-unmark-all
   (kbd "x") #'kubernetes-execute-marks

--- a/kubernetes-modes.el
+++ b/kubernetes-modes.el
@@ -53,6 +53,7 @@
     (define-key keymap (kbd "d") #'kubernetes-describe-popup)
     (define-key keymap (kbd "D") #'kubernetes-mark-for-delete)
     (define-key keymap (kbd "e") #'kubernetes-exec-popup)
+    (define-key keymap (kbd "f") #'kubernetes-file-popup)
     (define-key keymap (kbd "g") #'kubernetes-refresh)
     (define-key keymap (kbd "l") #'kubernetes-logs-popup)
     (define-key keymap (kbd "L") #'kubernetes-labels-popup)

--- a/kubernetes-popups.el
+++ b/kubernetes-popups.el
@@ -57,6 +57,7 @@
     "Popup commands"
     (?d "Describe" kubernetes-describe-popup)
     (?e "Exec" kubernetes-exec-popup)
+    (?f "File" kubernetes-file-popup)
     (?L "Labels" kubernetes-labels-popup)
     (?l "Logs" kubernetes-logs-popup)
     "Misc"
@@ -75,6 +76,17 @@
   :actions
   '((?e "Exec" kubernetes-exec-into))
   :default-action 'kubernetes-exec-into)
+
+(magit-define-popup kubernetes-file-popup
+  "Popup console for file commands for POD."
+  :group 'kubernetes
+  :options
+  '("Options for customizing file behaviour"
+    (?c "Container" "--container=" kubernetes-utils-read-container-name))
+  :actions
+  '((?f "Find file" kubernetes-tramp-find-file)
+    (?d "Dired" kubernetes-tramp-dired))
+  :default-action 'kubernetes-tramp-dired)
 
 (magit-define-popup kubernetes-describe-popup
   "Popup console for describe commands."

--- a/kubernetes-tramp.el
+++ b/kubernetes-tramp.el
@@ -1,0 +1,67 @@
+;;; kubernetes-tramp.el --- Tramp setup for kubernetes.  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021 Erik Hetzner
+
+;; Author: Erik Hetzner <egh@e6h.org>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'dash)
+(require 'tramp)
+
+(defun kubernetes-tramp--running-containers (&optional _ignored)
+  "A tramp-completion function for kubernetes."
+  (if (null (kubernetes-state))
+      (kubernetes-pods-refresh-now))
+  (-let (((&alist 'items pods) (kubernetes-state-pods (kubernetes-state))))
+    (-map (-lambda ((&alist 'metadata (&alist 'name)))
+            (list nil name))
+          pods)))
+
+(defun kubernetes-tramp-find-file (pod-name state)
+  (interactive (let* ((state (kubernetes-state))
+                      (pod-name (or (kubernetes-utils-maybe-pod-name-at-point) (kubernetes-utils-read-pod-name state))))
+                 (list pod-name state)))
+  (let ((default-directory (format "/kubernetes:%s:" pod-name)))
+    (call-interactively #'find-file)))
+
+(defun kubernetes-tramp-dired (pod-name container-name state)
+  (interactive (let* ((state (kubernetes-state))
+                      (pod-name (or (kubernetes-utils-maybe-pod-name-at-point) (kubernetes-utils-read-pod-name state)))
+                      (pod (kubernetes-state-lookup-pod pod-name state))
+                      (potential-containers (kubernetes-get-pod-container-names pod))
+                      (container-name (if (= 1 (length potential-containers))
+                                          (car potential-containers)
+                                        (kubernetes-utils-read-container-name))))
+                 (list pod-name container-name state)))
+  (dired (format "/kubernetes:%s@%s:" container-name pod-name)))
+
+(add-to-list 'tramp-methods
+             `("kubernetes"
+               (tramp-login-program ,kubernetes-kubectl-executable)
+               (tramp-login-args (("exec" "-i" "-t") ("-c" "%u") ("%h") ("--" "%l")))
+               (tramp-remote-shell "/bin/sh")
+               (tramp-remote-shell-login ("-l"))
+               (tramp-remote-shell-args ("-c"))
+               (tramp-connection-timeout 10)
+               (tramp-session-timeout 300)))
+
+(tramp-set-completion-function "kubernetes" '((kubernetes-tramp--running-containers "")))
+
+(provide 'kubernetes-tramp)
+;;; kubernetes-tramp.el ends here

--- a/kubernetes.el
+++ b/kubernetes.el
@@ -29,6 +29,7 @@
 (require 'kubernetes-labels)
 (require 'kubernetes-logs)
 (require 'kubernetes-overview)
+(require 'kubernetes-tramp)
 
 (provide 'kubernetes)
 


### PR DESCRIPTION
Add some basic tramp support.

Includes a new popup menu for files (`f`).

I abused the `user` parameter for tramp to support different containers for the same pod. This doesn't feel great, but since `user` is not a valid option for `kubectl exec` it shouldn't be a huge problem.

I'm unhappy with the container prompt logic. It is an option to the file commands, but magit-popup doesn't seem to support required parameters, and it would be very strange to open a file in a container without knowing which container in the pod was being used, it seems necessary to prompt the user for a container explicitly. But this feels strange with the magit-popup option as well.

I named the tramp method `kubernetes` to avoid a clash with the https://github.com/gruggiero/kubernetes-tramp project.

Screenshot of file popup menu:

![image](https://user-images.githubusercontent.com/22718/122486679-68790780-cf8e-11eb-9a38-287a07d93baf.png)
