### PR TITLE
Added new custom variable `kubernetes-pods-display-completed`

### DIFF
--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -125,8 +125,9 @@
                       (padding)))))
 
 (defun kubernetes-pods--succeeded-job-pod-p (pod)
-  (-let [(&alist 'status (&alist 'phase phase)) pod]
-    (equal phase "Succeeded")))
+  (unless kubernetes-pods-display-completed
+    (-let [(&alist 'status (&alist 'phase phase)) pod]
+      (equal phase "Succeeded"))))
 
 (kubernetes-ast-define-component pods-list (state &optional hidden)
   (-let (((&alist 'items pods) (kubernetes-state-pods state))

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -129,6 +129,10 @@ form \"--flag=value\" or \"-flag\"."
   :type '(repeat (string :tag "Argument"))
   :group 'kubernetes)
 
+(defcustom kubernetes-pods-display-completed nil
+  "If non-nil, display completed pods."
+  :group 'kubernetes
+  :type 'boolean)
 
 (defface kubernetes-context-name
   '((((class color) (background light)) :foreground "SkyBlue4")

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -138,7 +138,8 @@ will be mocked."
 
 (define-refresh-tests "pods" '("example-svc-v3-1603416598-2f9lb"
                                "example-svc-v4-1603416598-2f9lb"
-                               "example-svc-v5-1603416598-2f9lb"))
+                               "example-svc-v5-1603416598-2f9lb"
+                               "example-svc-v6-1603416598-2f9lb"))
 
 (ert-deftest kubernetes-kubectl-test--get-pods-returns-parsed-json ()
   (let* ((sample-response (test-helper-string-resource "get-pods-response.json"))

--- a/test/kubernetes-pods-test.el
+++ b/test/kubernetes-pods-test.el
@@ -58,10 +58,10 @@ Pods (0)
 
 ;; Shows pod lines when there are pods.
 
-(defconst kubernetes-pods-test--sample-result
+(defconst kubernetes-pods-test--sample-result-without-completed
   (s-trim-left "
 
-Pods (3)
+Pods (4)
   Name                                          Status     Ready   Restarts    Age
   example-svc-v3-1603416598-2f9lb               Running      1/1          0    36d
     Label:      example-pod-v3
@@ -96,13 +96,39 @@ Pods (3)
 
 "))
 
-(ert-deftest kubernetes-pods-test--sample-response ()
+(ert-deftest kubernetes-pods-test--sample-response-without-completed ()
   (let ((state `((pods . ,sample-get-pods-response)
                  (current-time . ,(date-to-time "2017-04-03 00:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-pods-section state)))
-      (should (equal kubernetes-pods-test--sample-result
+      (should (equal kubernetes-pods-test--sample-result-without-completed
+                     (substring-no-properties (buffer-string)))))))
+
+(defconst kubernetes-pods-test--sample-result-with-completed
+  (concat (s-trim-right kubernetes-pods-test--sample-result-without-completed) "
+
+  example-svc-v6-1603416598-2f9lb               Succeeded    0/1          0    36d
+    Label:      example-pod-v6
+    Namespace:  ns.example
+    Host IP:    10.27.111.26
+    Pod IP:     172.16.0.216
+    Started:    2017-02-25T08:13:39Z
+    Containers: (1)
+    - Name:     example-svc-v6
+      Image:    example.com/example-service:4.8.0
+
+
+"))
+
+(ert-deftest kubernetes-pods-test--sample-response-with-completed ()
+  (let ((state `((pods . ,sample-get-pods-response)
+                 (current-time . ,(date-to-time "2017-04-03 00:00Z"))))
+        (kubernetes-pods-display-completed t))
+    (with-temp-buffer
+      (save-excursion (magit-insert-section (root)
+                        (draw-pods-section state)))
+      (should (equal kubernetes-pods-test--sample-result-with-completed
                      (substring-no-properties (buffer-string)))))))
 
 

--- a/test/resources/get-pods-response.json
+++ b/test/resources/get-pods-response.json
@@ -415,7 +415,7 @@
         "startTime": "2017-02-25T08:12:14Z"
       }
     },
-        {
+    {
       "apiVersion": "v1",
       "kind": "Pod",
       "metadata": {
@@ -593,14 +593,170 @@
             "type": "PodScheduled"
           }
         ],
-
         "hostIP": "10.0.0.0",
         "phase": "Running",
         "podIP": "172.0.0.1",
         "startTime": "2017-02-25T08:12:14Z"
       }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "creationTimestamp": "2017-02-25T08:12:14Z",
+        "generateName": "setup-wizard-",
+        "labels": {
+          "name": "example-pod-v6",
+          "controller-uid": "502b3b8b-cccf-4ac0-bbe2-642d13bdb7a9",
+          "job-name": "example-svc-v6"
+        },
+        "name": "example-svc-v6-1603416598-2f9lb",
+        "namespace": "ns.example",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "Job",
+            "name": "example-svc-v6",
+            "uid": "502b3b8b-cccf-4ac0-bbe2-642d13bdb7a9"
+          }
+        ],
+        "resourceVersion": "14537",
+        "selfLink": "/api/v1/namespaces/ns.example/pods/example-svc-v6-1603416598-2f9lb",
+        "uid": "5c589ef2-4f40-4f88-8509-21fe3622890a"
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": [
+              "-c",
+              "echo dummy_run"
+            ],
+            "command": [
+              "/bin/sh"
+            ],
+            "image": "example.com/example-service:4.8.0",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "example-svc-v6",
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "6192Mi"
+              },
+              "requests": {
+                "cpu": "0",
+                "memory": "0"
+              }
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "default-token-469vw",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "nodeName": "10.27.111.26",
+        "priority": 0,
+        "restartPolicy": "Never",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+          {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+          },
+          {
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "tolerationSeconds": 300
+          }
+        ],
+        "volumes": [
+          {
+            "name": "default-token-469vw",
+            "secret": {
+              "defaultMode": 420,
+              "secretName": "default-token-469vw"
+            }
+          }
+        ]
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:12:14Z",
+            "reason": "PodCompleted",
+            "status": "True",
+            "type": "Initialized"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:13:39Z",
+            "reason": "PodCompleted",
+            "status": "False",
+            "type": "Ready"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:12:14Z",
+            "reason": "PodCompleted",
+            "status": "False",
+            "type": "ContainersReady"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:12:14Z",
+            "status": "True",
+            "type": "PodScheduled"
+          }
+        ],
+        "containerStatuses": [
+          {
+            "containerID": "docker://2557cb6ce7c64b181a899471fe80a652cef3537b0849e37a3f8b5a6877c3e0df",
+            "image": "example.com/example-service:4.8.0",
+            "imageID": "docker://sha256:cf059c1fbc2bcaac7e93db0d38d0149090137ec6f578b3386a1143f1defadac3",
+            "lastState": {},
+            "name": "example-svc-v6",
+            "ready": false,
+            "restartCount": 0,
+            "started": false,
+            "state": {
+              "terminated": {
+                "containerID": "docker://2557cb6ce7c64b181a899471fe80a652cef3537b0849e37a3f8b5a6877c3e0df",
+                "exitCode": 0,
+                "finishedAt": "2017-02-25T08:14:00Z",
+                "reason": "Completed",
+                "startedAt": "2017-02-25T08:13:39Z"
+              }
+            }
+          }
+        ],
+        "hostIP": "10.27.111.26",
+        "phase": "Succeeded",
+        "podIP": "172.16.0.216",
+        "podIPs": [
+          {
+            "ip": "172.16.0.216"
+          }
+        ],
+        "qosClass": "Burstable",
+        "startTime": "2017-02-25T08:13:39Z"
+      }
     }
-
   ],
   "kind": "List",
   "metadata": {},


### PR DESCRIPTION
Today we are filtering out pods with Succeeded phase in the pods' list
view. Introduced a new custom variable to configure this behavior. If
the value of the variable is non-nil, then display all the pods.

Fixes #166 