### PR TITLE
Faces: Replace magit-dimmed with kubernetes-dimmed

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -268,7 +268,7 @@ POD-NAME is the name of the pod to describe."
       (let ((inhibit-read-only t))
         (erase-buffer)
         (set-marker marker (point))
-        (insert (propertize "Loading..." 'face 'magit-dimmed))))
+        (insert (propertize "Loading..." 'face 'kubernetes-dimmed))))
     (let* ((populate-buffer (lambda (s)
                               (with-current-buffer (marker-buffer marker)
                                 (setq-local tab-width 8)

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -40,12 +40,12 @@
                          (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Data
-                         (propertize (format (pop list-fmt) (seq-length data)) 'face 'magit-dimmed)
+                         (propertize (format (pop list-fmt) (seq-length data)) 'face 'kubernetes-dimmed)
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
     `(nav-prop (:configmap-name ,name)
                (copy-prop ,name
                           ,(cond

--- a/kubernetes-contexts.el
+++ b/kubernetes-contexts.el
@@ -30,7 +30,7 @@
                          (key-value 12 "Namespace" ,(propertize namespace-in-use 'face 'kubernetes-namespace)))))))
 
 (defun kubernetes-contexts--render-namespace-only (current-namespace)
-  (let ((none (propertize "<none>" 'face 'magit-dimmed)))
+  (let ((none (propertize "<none>" 'face 'kubernetes-dimmed)))
     `((heading (nav-prop :display-config (key-value 12 "Context" ,none)))
       (section (namespace nil)
                (nav-prop (:namespace-name ,current-namespace)

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -78,7 +78,7 @@
                             ((/= current desired)
                              (format next str))
                             (t
-                             (propertize (format next str) 'face 'magit-dimmed))))
+                             (propertize (format next str) 'face 'kubernetes-dimmed))))
                          " "
                          ;; Up-to-date
                          (let ((next (pop list-fmt)))
@@ -88,7 +88,7 @@
                             ((zerop up-to-date)
                              (propertize (format next up-to-date) 'face 'warning))
                             (t
-                             (propertize (format next up-to-date) 'face 'magit-dimmed))))
+                             (propertize (format next up-to-date) 'face 'kubernetes-dimmed))))
                          " "
                          ;; Available
                          (let ((next (pop list-fmt)))
@@ -98,12 +98,12 @@
                             ((zerop available)
                              (propertize (format next available) 'face 'warning))
                             (t
-                             (propertize (format next available) 'face 'magit-dimmed))))
+                             (propertize (format next available) 'face 'kubernetes-dimmed))))
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
     `(nav-prop (:deployment-name ,name)
                (copy-prop ,name
                           ,(cond
@@ -112,7 +112,7 @@
                             ((member name marked-deployments)
                              `(mark-for-delete ,line))
                             ((zerop desired)
-                             `(propertize (face magit-dimmed) ,line))
+                             `(propertize (face kubernetes-dimmed) ,line))
                             (t
                              line))))))
 

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -53,7 +53,7 @@
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format "%10s" (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
 
     `(nav-prop (:ingress-name ,name)
                (copy-prop ,name

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -69,19 +69,19 @@
                  (let ((name-str (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))))
                    (cond
                     ((and completion-time (< 0 successful))
-                     (propertize name-str 'face 'magit-dimmed))
+                     (propertize name-str 'face 'kubernetes-dimmed))
                     ((not (kubernetes-pod-line-ok-p pod))
                      (propertize name-str 'face 'warning))
                     (t
                      name-str)))
                  " "
                  ;; Successful
-                 (propertize (format (pop list-fmt) successful) 'face 'magit-dimmed)
+                 (propertize (format (pop list-fmt) successful) 'face 'kubernetes-dimmed)
                  " "
                  ;; Age
                  (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                    (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                               'face 'magit-dimmed)))))
+                               'face 'kubernetes-dimmed)))))
 
     `(nav-prop (:job-name ,name)
                (copy-prop ,name

--- a/kubernetes-loading-container.el
+++ b/kubernetes-loading-container.el
@@ -10,6 +10,7 @@
 ;;; Code:
 
 (require 'kubernetes-ast)
+(require 'kubernetes-vars)
 
 (kubernetes-ast-define-component membership-loading-discriminator (elem vector &key on-loading on-found on-not-found)
   (cond
@@ -58,7 +59,7 @@
                  (line "Fetching...")))
 
     :on-empty
-    (propertize (face magit-dimmed) (line "None."))
+    (propertize (face kubernetes-dimmed) (line "None."))
 
     :on-populated
     (,@(when column-header

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -56,7 +56,7 @@
             (let ((s (kubernetes-utils-ellipsize type 10)))
               (format (pop list-fmt)
                       (if (string-match-p "running" type)
-                          (propertize s 'face 'magit-dimmed)
+                          (propertize s 'face 'kubernetes-dimmed)
                         s)))
             " "
             ;; Roles
@@ -75,12 +75,12 @@
             ;; Age
             (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp creationTimestamp))))
               (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                          'face 'magit-dimmed))
+                          'face 'kubernetes-dimmed))
             " "
             ;; Version
             (format (pop list-fmt)
                     (propertize (kubernetes-utils-ellipsize kubeProxyVersion 8)
-                                'face 'magit-dimmed))))
+                                'face 'kubernetes-dimmed))))
           (str (cond
                 ((string-match-p "ready" type) str)
                 (t (propertize str 'face 'warning))))

--- a/kubernetes-pod-line.el
+++ b/kubernetes-pod-line.el
@@ -24,7 +24,7 @@
           (state-face
            (cond
             ((member (downcase pod-state) '("running" "containercreating" "terminated"))
-             'magit-dimmed)
+             'kubernetes-dimmed)
             ((member (downcase pod-state) '("runcontainererror" "crashloopbackoff"))
              'error)
             ((equal (downcase pod-state) "succeeded")

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -72,7 +72,7 @@
             " "
             ;; Status
             (let ((s (format (pop list-fmt) (kubernetes-utils-ellipsize pod-state 10))))
-              (if (equal pod-state "Running") (propertize s 'face 'magit-dimmed) s))
+              (if (equal pod-state "Running") (propertize s 'face 'kubernetes-dimmed) s))
             " "
             ;; Ready
             (format (pop list-fmt)
@@ -82,13 +82,13 @@
                            (count-str (format "%s/%s" n-ready (seq-length containers))))
                       (if (zerop n-ready)
                           count-str
-                        (propertize count-str 'face 'magit-dimmed))))
+                        (propertize count-str 'face 'kubernetes-dimmed))))
             " "
             ;; Restarts
             (let ((s (format (pop list-fmt) restarts)))
               (cond
                ((equal 0 restarts)
-                (propertize s 'face 'magit-dimmed))
+                (propertize s 'face 'kubernetes-dimmed))
                ((<= kubernetes-pod-restart-warning-threshold restarts)
                 (propertize s 'face 'warning))
                (t
@@ -97,7 +97,7 @@
             ;; Age
             (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp start-time))))
               (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                          'face 'magit-dimmed))))
+                          'face 'kubernetes-dimmed))))
           (str (cond
                 ((member (downcase pod-state) '("running" "containercreating" "terminated"))
                  str)

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -38,12 +38,12 @@
                          (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Data
-                         (propertize (format (pop list-fmt) (seq-length data)) 'face 'magit-dimmed)
+                         (propertize (format (pop list-fmt) (seq-length data)) 'face 'kubernetes-dimmed)
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
     `(nav-prop (:secret-name ,name)
                (copy-prop ,name
                           ,(cond

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -69,16 +69,16 @@
                          (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
                          " "
                          ;; Internal IP
-                         (propertize (format (pop list-fmt) internal-ip) 'face 'magit-dimmed)
+                         (propertize (format (pop list-fmt) internal-ip) 'face 'kubernetes-dimmed)
                          " "
                          ;; External IP
                          (let ((ips (append external-ips nil)))
-                           (propertize (format (pop list-fmt) (or (car ips) "")) 'face 'magit-dimmed))
+                           (propertize (format (pop list-fmt) (or (car ips) "")) 'face 'kubernetes-dimmed))
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
     `(nav-prop (:service-name ,name)
                (copy-prop ,name
                           ,(cond

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -78,18 +78,18 @@
                             ((/= current desired)
                              (format next str))
                             (t
-                             (propertize (format next str) 'face 'magit-dimmed))))
+                             (propertize (format next str) 'face 'kubernetes-dimmed))))
                          " "
                          ;; Up-to-date
                          (propertize (format (pop list-fmt) "") 'face 'warning)
                          " "
                          ;; Available
-                         (propertize (format (pop list-fmt) "") 'face 'magit-dimmed)
+                         (propertize (format (pop list-fmt) "") 'face 'kubernetes-dimmed)
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format (pop list-fmt) (kubernetes-utils-time-diff-string start current-time))
-                                       'face 'magit-dimmed))))))
+                                       'face 'kubernetes-dimmed))))))
     `(nav-prop (:statefulset-name ,name)
                (copy-prop ,name
                           ,(cond
@@ -98,7 +98,7 @@
                             ((member name marked-statefulsets)
                              `(mark-for-delete ,line))
                             ((zerop desired)
-                             `(propertize (face magit-dimmed) ,line))
+                             `(propertize (face kubernetes-dimmed) ,line))
                             (t
                              line))))))
 

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -116,9 +116,9 @@ buffer is killed."
       (let ((time-str (format "Session started at %s" (substring (current-time-string) 0 19)))
             (command-str (format "%s %s" command (string-join args " "))))
         (kubernetes-ast-eval
-         `((line ,(propertize time-str 'face 'magit-dimmed))
+         `((line ,(propertize time-str 'face 'kubernetes-dimmed))
            (padding)
-           (line ,(propertize command-str 'face 'magit-dimmed))
+           (line ,(propertize command-str 'face 'kubernetes-dimmed))
            (padding))))
 
       (term-exec (current-buffer) "kuberenetes-term" command nil args)
@@ -156,9 +156,9 @@ buffer is killed."
         (let ((time-str (format "Process started at %s" (substring (current-time-string) 0 19)))
               (command-str (format "%s %s" command (string-join args " "))))
           (kubernetes-ast-eval
-           `((line ,(propertize time-str 'face 'magit-dimmed))
+           `((line ,(propertize time-str 'face 'kubernetes-dimmed))
              (padding)
-             (line ,(propertize command-str 'face 'magit-dimmed))
+             (line ,(propertize command-str 'face 'kubernetes-dimmed))
              (padding))))))
 
     (let ((proc (apply #'start-process "kubernetes-exec" buf command args)))

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -134,6 +134,12 @@ form \"--flag=value\" or \"-flag\"."
   :group 'kubernetes
   :type 'boolean)
 
+(defface kubernetes-dimmed
+  '((((class color) (background light)) :foreground "grey50")
+    (((class color) (background dark)) :foreground "grey50"))
+  "Face for text that shouldn't stand out."
+  :group 'kubernetes)
+
 (defface kubernetes-context-name
   '((((class color) (background light)) :foreground "SkyBlue4")
     (((class color) (background  dark)) :foreground "LightSkyBlue1"))

--- a/test/kubernetes-configmaps-test.el
+++ b/test/kubernetes-configmaps-test.el
@@ -53,7 +53,7 @@ Configmaps (0)
       (should (equal kubernetes-configmaps-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows configmap lines when there are configmaps.

--- a/test/kubernetes-contexts-test.el
+++ b/test/kubernetes-contexts-test.el
@@ -28,7 +28,7 @@ Context:    Fetching...
     (should (equal kubernetes-contexts-test--loading-result
                    (substring-no-properties (buffer-string))))
     (search-forward-regexp (rx "Context:" (+ space)))
-    (should (equal 'magit-dimmed (get-text-property (point) 'face)))))
+    (should (equal 'kubernetes-dimmed (get-text-property (point) 'face)))))
 
 
 ;; When there is a namespace set but no context, show the namespace with <none>
@@ -49,7 +49,7 @@ Namespace:  example-ns
     (should (equal kubernetes-contexts-test--just-namespace
                    (substring-no-properties (buffer-string))))
     (search-forward-regexp (rx "Context:" (+ space)))
-    (should (equal 'magit-dimmed (get-text-property (point) 'face)))))
+    (should (equal 'kubernetes-dimmed (get-text-property (point) 'face)))))
 
 
 ;; When state is initialized, shows current information.

--- a/test/kubernetes-deployments-test.el
+++ b/test/kubernetes-deployments-test.el
@@ -53,7 +53,7 @@ Deployments (0)
       (should (equal kubernetes-deployments-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows deployment lines when there are deployments.

--- a/test/kubernetes-ingress-test.el
+++ b/test/kubernetes-ingress-test.el
@@ -53,7 +53,7 @@ Ingress (0)
       (should (equal kubernetes-ingress-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows ingress lines when there are ingress.

--- a/test/kubernetes-jobs-test.el
+++ b/test/kubernetes-jobs-test.el
@@ -54,7 +54,7 @@ Jobs (0)
       (should (equal kubernetes-jobs-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows job lines when there are jobs.

--- a/test/kubernetes-nodes-test.el
+++ b/test/kubernetes-nodes-test.el
@@ -53,7 +53,7 @@ Nodes (0)
       (should (equal kubernetes-nodes-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 ;; Shows node lines when there are nodes.
 

--- a/test/kubernetes-pods-test.el
+++ b/test/kubernetes-pods-test.el
@@ -53,7 +53,7 @@ Pods (0)
       (should (equal kubernetes-pods-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows pod lines when there are pods.

--- a/test/kubernetes-secrets-test.el
+++ b/test/kubernetes-secrets-test.el
@@ -53,7 +53,7 @@ Secrets (0)
       (should (equal kubernetes-secrets-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows secret lines when there are secrets.

--- a/test/kubernetes-services-test.el
+++ b/test/kubernetes-services-test.el
@@ -53,7 +53,7 @@ Services (0)
       (should (equal kubernetes-services-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows service lines when there are services.

--- a/test/kubernetes-statefulsets-test.el
+++ b/test/kubernetes-statefulsets-test.el
@@ -53,7 +53,7 @@ Statefulsets (0)
       (should (equal kubernetes-statefulsets-test--empty-result
                      (substring-no-properties (buffer-string))))
       (search-forward "None")
-      (should (equal 'magit-dimmed (get-text-property (point) 'face))))))
+      (should (equal 'kubernetes-dimmed (get-text-property (point) 'face))))))
 
 
 ;; Shows statefulset lines when there are statefulsets.


### PR DESCRIPTION
Partially addresses #2.

This PR replaces all use of the Magit face `magit-dimmed` with
`kubernetes-dimmed`, a carbon copy thereof.