### PR TITLE
Faces: Replace magit-header-line w/ magit-section-heading

### DIFF
--- a/kubernetes-ast.el
+++ b/kubernetes-ast.el
@@ -7,6 +7,7 @@
 
 (require 'cl-lib)
 (require 'magit)
+(require 'magit-section)
 (require 'subr-x)
 
 ;; Derived component support.
@@ -54,7 +55,7 @@ such in rendering ASTs." name)))
   (cl-assert (stringp key) t)
   (cl-assert (stringp value) t)
   (let* ((fmt-string (concat "%-" (number-to-string width) "s"))
-         (str (concat (propertize (format fmt-string (concat key ": ")) 'face 'magit-header-line)
+         (str (concat (propertize (format fmt-string (concat key ": ")) 'face 'magit-section-heading)
                       value)))
     (unless (string-blank-p (buffer-substring (line-beginning-position) (line-end-position)))
       (newline))

--- a/kubernetes-loading-container.el
+++ b/kubernetes-loading-container.el
@@ -10,6 +10,7 @@
 ;;; Code:
 
 (require 'kubernetes-ast)
+(require 'magit-section)
 
 (kubernetes-ast-define-component membership-loading-discriminator (elem vector &key on-loading on-found on-not-found)
   (cond
@@ -66,7 +67,7 @@
      ,@loaded-content)))
 
 (kubernetes-ast-define-component header-with-count (header resource-vector)
-  (let ((header (propertize header 'face 'magit-header-line)))
+  (let ((header (propertize header 'face 'magit-section-heading)))
     `(heading
       (emptiness-loading-discriminator
        ,resource-vector

--- a/test/kubernetes-configmaps-test.el
+++ b/test/kubernetes-configmaps-test.el
@@ -95,7 +95,7 @@ Configmaps (2)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-configmaps-test.el ends here

--- a/test/kubernetes-deployments-test.el
+++ b/test/kubernetes-deployments-test.el
@@ -97,7 +97,7 @@ Deployments (2)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-deployments-test.el ends here

--- a/test/kubernetes-ingress-test.el
+++ b/test/kubernetes-ingress-test.el
@@ -103,7 +103,7 @@ Ingress (4)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-ingress-test.el ends here

--- a/test/kubernetes-nodes-test.el
+++ b/test/kubernetes-nodes-test.el
@@ -106,6 +106,6 @@ Nodes (1)
                      "systemUUID"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 ;;; kubernetes-nodes-test.el ends here

--- a/test/kubernetes-pods-test.el
+++ b/test/kubernetes-pods-test.el
@@ -150,6 +150,6 @@ Pods (4)
                      "Started"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 ;;; kubernetes-pods-test.el ends here

--- a/test/kubernetes-secrets-test.el
+++ b/test/kubernetes-secrets-test.el
@@ -96,7 +96,7 @@ Secrets (2)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-secrets-test.el ends here

--- a/test/kubernetes-services-test.el
+++ b/test/kubernetes-services-test.el
@@ -105,7 +105,7 @@ Services (2)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-services-test.el ends here

--- a/test/kubernetes-statefulsets-test.el
+++ b/test/kubernetes-statefulsets-test.el
@@ -91,7 +91,7 @@ Statefulsets (1)
                      "Created"))
         (save-excursion
           (search-forward key)
-          (should (equal 'magit-header-line (get-text-property (point) 'face))))))))
+          (should (equal 'magit-section-heading (get-text-property (point) 'face))))))))
 
 
 ;;; kubernetes-statefulsets-test.el ends here


### PR DESCRIPTION
Partially addresses #2.

This PR replaces all use of the `magit-header-line` face with
`magit-section-heading`, which the former directly inherits from
without modification (see [definition in
`magit/magit/lisp/magit.el`](https://github.com/magit/magit/blob/master/lisp/magit.el#L71-L77)).

This change will help us slowly obviate our dependency on `magit`
itself in favor of `magit-section` and `transient`.