### PR TITLE
Remove more traces of core Magit package

### DIFF
--- a/kubernetes-ast.el
+++ b/kubernetes-ast.el
@@ -6,7 +6,6 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'magit)
 (require 'magit-section)
 (require 'subr-x)
 

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -11,6 +11,7 @@
 (require 'kubernetes-state)
 (require 'kubernetes-utils)
 (require 'kubernetes-yaml)
+(require 'magit-section)
 
 
 ;; Components

--- a/kubernetes-modes.el
+++ b/kubernetes-modes.el
@@ -2,7 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-(require 'magit)
+(require 'magit-section)
 (require 'subr-x)
 
 (autoload 'kubernetes-config-popup "kubernetes-popups")

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -168,12 +168,12 @@ form \"--flag=value\" or \"-flag\"."
   :group 'kubernetes)
 
 (defface kubernetes-selector
-  '((t :inherit magit-branch-remote))
+  '((t :foreground "DarkSeaGreen2"))
   "Face for labels used as selectors."
   :group 'kubernetes)
 
 (defface kubernetes-namespace
-  '((t :inherit magit-tag))
+  '((t :foreground "LightGoldenrod2"))
   "Face for namespace references."
   :group 'kubernetes)
 


### PR DESCRIPTION
Partially addresses #2.

This PR replaces the `magit-branch-remote` and `magit-tag` parent
faces with their literal counterparts. I believe this is the last of
the faces inherited from Magit proper.

Incidentally, this PR also replaces some `require`s of `magit` in
packages that only use `magit-section` constructs with
`magit-section`, helping to further remove dependency on Magit proper.