### PR TITLE
Deps: Remove magit in favor of magit-section

### DIFF
--- a/kubernetes.el
+++ b/kubernetes.el
@@ -9,7 +9,7 @@
 
 ;; Version: 0.15.0
 
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit "2.8.0") (magit-popup "2.13.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Closes #151.

Now that all Magit-inherited faces have been replaced by faces we
define within the package itself (see #2), we can safely eliminate the
dependency on Magit itself.

We do so here, swapping out `magit` for the tighter-scoped
`magit-section`, which additionally is actually designed for
consumption as a package dependency.