### PR TITLE
Added edit resource functionality (Partial fix for #124)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ This project is in early stages, but the following are implemented:
 
 - Live-updating lists of kubernetes resources
 - Viewing and deleting pods, configmaps and secrets
+- Editing various Kubernetes resources like deployment, configmap, etc.
 - Switching contexts and namespaces.
 - Showing logs and exec'ing into containers
 - Describing pods

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -452,6 +452,48 @@ CONTEXT is the name of a context as a string."
           ((&alist 'contexts contexts) config))
     (--map (alist-get 'name it) contexts)))
 
+(defun kubernetes--edit-resource (kind name)
+  (kubernetes-kubectl-edit-resource kubernetes-props
+                                    (kubernetes-state)
+                                    kind
+                                    name
+                                    (lambda (buf)
+                                      (let ((s (with-current-buffer buf (buffer-string))))
+                                        (message "Edited resource %s of kind %s" name kind)
+                                        (message s)))
+                                    (lambda (buf)
+                                      (let ((s (with-current-buffer buf (buffer-string))))
+                                        (message "Editing resource %s of kind %s failed" name kind)
+                                        (message s)))))
+
+;;;###autoload
+(defun kubernetes-edit-resource-dwim (thing)
+  "Edit the resource at point.
+
+THING must be a valid target for `kubectl edit'."
+  (interactive (list (kubernetes--describable-thing-at-pt)))
+  (pcase thing
+    (`(:configmap-name ,name)
+     (kubernetes--edit-resource "configmap" name))
+    (`(:deployment-name ,name)
+     (kubernetes--edit-resource "deployment" name))
+    (`(:ingress-name ,name)
+     (kubernetes--edit-resource "ingress" name))
+    (`(:job-name ,name)
+     (kubernetes--edit-resource "job" name))
+    (`(:pod-name ,name)
+     (kubernetes--edit-resource "node" name))
+    (`(:node-name ,name)
+     (kubernetes--edit-resource "pod" name))
+    (`(:secret-name ,name)
+     (kubernetes--edit-resource "secret" name))
+    (`(:service-name ,name)
+     (kubernetes--edit-resource "service" name))
+    (`(:statefulset-name ,name)
+     (kubernetes--edit-resource "statefulset" name))
+    (_
+     (user-error "Nothing at point to edit"))))
+
 (provide 'kubernetes-commands)
 
 ;;; kubernetes-commands.el ends here

--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'with-editor)
 
 (require 'kubernetes-process)
 (require 'kubernetes-props)
@@ -518,6 +519,23 @@ to a function of the type:
       (sleep-for 0.001))
 
     result))
+
+(defun kubernetes-kubectl-edit-resource (props state kind resource-name cb &optional error-cb)
+  "Edit resource of kind KIND with RESOURCE-NAME, then execute CB
+with the response buffer.
+
+PROPS is an alist of functions to inject.  It should normally be passed
+`kubernetes-props'.
+
+STATE is the application state.
+
+ERROR-CB is called if an error occurred."
+  (with-editor
+    (kubernetes-kubectl props
+                        state
+                        (list "edit" kind resource-name)
+                        cb
+                        error-cb)))
 
 (provide 'kubernetes-kubectl)
 

--- a/kubernetes-modes.el
+++ b/kubernetes-modes.el
@@ -53,6 +53,7 @@
     (define-key keymap (kbd "d") #'kubernetes-describe-popup)
     (define-key keymap (kbd "D") #'kubernetes-mark-for-delete)
     (define-key keymap (kbd "e") #'kubernetes-exec-popup)
+    (define-key keymap (kbd "E") #'kubernetes-edit-popup)
     (define-key keymap (kbd "f") #'kubernetes-file-popup)
     (define-key keymap (kbd "g") #'kubernetes-refresh)
     (define-key keymap (kbd "l") #'kubernetes-logs-popup)

--- a/kubernetes-popups.el
+++ b/kubernetes-popups.el
@@ -56,6 +56,7 @@
     (?U "Unmark all" kubernetes-unmark-all)
     "Popup commands"
     (?d "Describe" kubernetes-describe-popup)
+    (?E "Edit" kubernetes-edit-popup)
     (?e "Exec" kubernetes-exec-popup)
     (?f "File" kubernetes-file-popup)
     (?L "Labels" kubernetes-labels-popup)
@@ -103,6 +104,13 @@
   :actions
   '((?p "Pods" kubernetes-show-pods-for-label))
   :default-action 'kubernetes-show-pods-for-label)
+
+(magit-define-popup kubernetes-edit-popup
+  "Popup console for commands relating to edit resources."
+  :group 'kubernetes
+  :actions
+  '((?e "Edit (dwim)" kubernetes-edit-resource-dwim))
+  :default-action 'kubernetes-edit-resource-dwim)
 
 
 ;; Config popup

--- a/kubernetes.el
+++ b/kubernetes.el
@@ -9,7 +9,7 @@
 
 ;; Version: 0.15.0
 
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -514,4 +514,33 @@ will be mocked."
     (kubernetes-kubectl--default-error-handler props "killed: 9")
     (should-not message-called-p)))
 
+;; Edit resource
+
+(ert-deftest kubernetes-kubectl-test--edit-resource-succeeds ()
+  (let ((deployment-name "example-deployment"))
+    (with-successful-response-at
+     (list "edit" "deployment" deployment-name) deployment-name
+     (kubernetes-kubectl-edit-resource kubernetes-kubectl-test-props
+                                       nil
+                                       "deployment"
+                                       deployment-name
+                                       (lambda (buf)
+                                         (let ((s (with-current-buffer buf (buffer-string))))
+                                           (should (equal deployment-name s))))))))
+
+(ert-deftest kubernetes-kubectl-test--edit-resource-fails ()
+  (let ((on-error-called)
+        (deployment-name "example-deployment"))
+    (with-error-response-at
+     (list "edit" "deployment" "example-deployment") deployment-name
+     (kubernetes-kubectl-edit-resource kubernetes-kubectl-test-props
+                                       nil
+                                       "deployment"
+                                       deployment-name
+                                       (lambda (_)
+                                         (error "Unexpected success response"))
+                                       (lambda (_)
+                                         (setq on-error-called t))))
+    (should on-error-called)))
+
 ;;; kubernetes-kubectl-test.el ends here


### PR DESCRIPTION
* Added new pop-up key E, as e is unavailable.
* Used with-editor package as the driver for this functionality.
* Added tests

Why is this fix partial?

* I am exploring a way to provide custom key bindings to the edit
  buffer like the Magit commit buffer. But I am not successful yet.