### PR TITLE
Make some util functions resilient to unexpected calling contexts

### DIFF
--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -33,14 +33,14 @@
   (-let [(&alist 'spec (&alist 'containers containers)) pod]
     (-map (-lambda ((&alist 'name name)) name) containers)))
 
-(define-error 'k8s-state-error "Kubernetes state not initialized")
+(define-error 'kubernetes-state-error "Kubernetes state not initialized")
 
 (defun kubernetes-utils-read-container-name (&rest _)
   "Read a container name from the pod at POINT or a user-supplied pod.
 
 This function will error if `kubernetes-state' is not
 initialized."
-  (letrec ((state (or (kubernetes-state) (signal 'k8s-state-error nil)))
+  (letrec ((state (or (kubernetes-state) (signal 'kubernetes-state-error nil)))
            (pod-name (or (kubernetes-utils-maybe-pod-name-at-point)
                          (kubernetes-utils-read-pod-name state)))
            (pod (kubernetes-state-lookup-pod pod-name state))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -36,7 +36,10 @@
 (define-error 'k8s-state-error "Kubernetes state not initialized")
 
 (defun kubernetes-utils-read-container-name (&rest _)
-  "Read a container name from the pod at POINT or a user-supplied pod."
+  "Read a container name from the pod at POINT or a user-supplied pod.
+
+This function will error if `kubernetes-state' is not
+initialized."
   (letrec ((state (or (kubernetes-state) (signal 'k8s-state-error nil)))
            (pod-name (or (kubernetes-utils-maybe-pod-name-at-point)
                          (kubernetes-utils-read-pod-name state)))

--- a/test/kubernetes-utils-test.el
+++ b/test/kubernetes-utils-test.el
@@ -12,6 +12,6 @@
 
 (ert-deftest kubernetes-utils-test--read-container-name--no-state ()
   (cl-letf (((symbol-function 'kubernetes-state) #'ignore))
-    (should-error (kubernetes-utils-read-container-name) :type 'k8s-state-error)))
+    (should-error (kubernetes-utils-read-container-name) :type 'kubernetes-state-error)))
 
 ;;; kubernetes-utils-test.el ends here

--- a/test/kubernetes-utils-test.el
+++ b/test/kubernetes-utils-test.el
@@ -1,0 +1,17 @@
+;;; kubernetes-utils-test.el --- Test util functions -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'kubernetes-overview)
+(require 'kubernetes-utils)
+
+(ert-deftest kubernetes-utils-test--maybe-pod-name-at-point--not-in-overview-buffer ()
+  (ignore-errors
+    (kill-buffer kubernetes-overview-buffer-name))
+  (should-not (kubernetes-utils-maybe-pod-name-at-point)))
+
+(ert-deftest kubernetes-utils-test--read-container-name--no-state ()
+  (cl-letf (((symbol-function 'kubernetes-state) #'ignore))
+    (should-error (kubernetes-utils-read-container-name) :type 'k8s-state-error)))
+
+;;; kubernetes-utils-test.el ends here


### PR DESCRIPTION
This PR hardens the following functions against invocation in unexpected
contexts, e.g. when `kubernetes-state` is `nil` or when the overview buffer
isn't available:
- `kubernetes-utils-read-container-name`
- `kubernetes-utils-maybe-pod-name-at-point`

We also contribute unit tests accordingly.