### PR TITLE
Add unit tests for `kubernetes-get-pod-container-names`

### DIFF
--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -29,7 +29,9 @@
                                tz))))
 
 (defun kubernetes-get-pod-container-names (pod)
-  "Return the names of all containers available in the specified pod."
+  "Return the names of all containers available in the specified POD.
+
+Returns nil on invalid input."
   (-let [(&alist 'spec (&alist 'containers containers)) pod]
     (-map (-lambda ((&alist 'name name)) name) containers)))
 

--- a/test/kubernetes-utils-test.el
+++ b/test/kubernetes-utils-test.el
@@ -2,8 +2,19 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 'dash)
+
 (require 'kubernetes-overview)
 (require 'kubernetes-utils)
+(declare-function test-helper-json-resource "test-helper.el")
+
+(ert-deftest kubernetes-utils-test--get-pod-container-names--invalid-input ()
+  (should (equal nil (kubernetes-get-pod-container-names '()))))
+
+(ert-deftest kubernetes-utils-test--get-pod-container-names ()
+  (-let* ((res (test-helper-json-resource "get-pods-response.json"))
+          ((&alist 'items [pod]) res))
+    (should (equal '("example-service-1") (kubernetes-get-pod-container-names pod)))))
 
 (ert-deftest kubernetes-utils-test--maybe-pod-name-at-point--not-in-overview-buffer ()
   (ignore-errors


### PR DESCRIPTION
Additionally, we document and test for the expected behavior on invalid input,
e.g. empty a-list.