### PR TITLE
Genericize `kubectl get` operations

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -415,7 +415,7 @@ STATE is the current application state."
   (kubernetes-state-trigger-redraw))
 
 (defun kubernetes--namespace-names (state)
-  (-let* ((config (or (kubernetes-state-namespaces state) (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-namespaces)))
+  (-let* ((config (or (kubernetes-state-namespaces state) (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "namespaces"))))
           ((&alist 'items items) config))
     (-map (-lambda ((&alist 'metadata (&alist 'name name))) name) items)))
 

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -108,7 +108,7 @@ Update the configmap state if it not set yet."
            (or (kubernetes-state-configmaps state)
                (progn
                  (message "Getting configmaps...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-configmaps)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "configmaps"))))
                    (kubernetes-state-update-configmaps response)
                    response))))
           (configmaps (append configmaps nil))

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -167,7 +167,7 @@ Update the deployment state if it not set yet."
            (or (kubernetes-state-deployments state)
                (progn
                  (message "Getting deployments...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-deployments)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "deployments"))))
                    (kubernetes-state-update-deployments response)
                    response))))
           (deployments (append deployments nil))

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -110,7 +110,7 @@ Update the ingress state if it not set yet."
            (or (kubernetes-state-ingress state)
                (progn
                  (message "Getting ingress...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-ingress)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "ingress"))))
                    (kubernetes-state-update-ingress response)
                    response))))
           (ingress (append ingress nil))

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -152,7 +152,7 @@ Update the job state if it not set yet."
            (or (kubernetes-state-jobs state)
                (progn
                  (message "Getting jobs...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-jobs)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "jobs"))))
                    (kubernetes-state-update-jobs response)
                    response))))
           (jobs (append jobs nil))

--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -97,6 +97,23 @@ Returns the process object for this execution of kubectl."
 
     proc))
 
+(defun kubernetes-kubectl-get (resource props state cb &optional cleanup-cb)
+  "Get all of a given RESOURCE and execute callback CB with the parsed JSON.
+
+PROPS is an alist of functions to inject.  It should normally be passed
+`kubernetes-props'.
+
+STATE is the application state.
+
+CLEANUP-CB is a function taking no arguments used to release any resources."
+  (kubernetes-kubectl props state `("get" ,resource "-o" "json")
+                      (lambda (buf)
+                        (let ((json (with-current-buffer buf
+                                      (json-read-from-string (buffer-string)))))
+                          (funcall cb json)))
+                      nil
+                      cleanup-cb))
+
 (defun kubernetes-kubectl-get-pods (props state cb &optional cleanup-cb)
   "Get all pods and execute callback CB with the parsed JSON.
 
@@ -106,13 +123,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "pods" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "pods" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-nodes (props state cb &optional cleanup-cb)
   "Get all nodes and execute callback CB with the parsed JSON.
@@ -123,13 +134,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "nodes" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "nodes" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-configmaps (props state cb &optional cleanup-cb)
   "Get all configmaps and execute callback CB with the parsed JSON.
@@ -140,13 +145,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "configmaps" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "configmaps" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-deployments (props state cb &optional cleanup-cb)
   "Get all deployments and execute callback CB with the parsed JSON.
@@ -157,13 +156,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "deployments" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "deployments" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-statefulsets (props state cb &optional cleanup-cb)
   "Get all statefulsets and execute callback CB with the parsed JSON.
@@ -174,13 +167,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "statefulsets" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "statefulsets" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-ingress (props state cb &optional cleanup-cb)
   "Get all ingress and execute callback CB with the parsed JSON.
@@ -191,13 +178,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "ingress" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "ingress" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-jobs (props state cb &optional cleanup-cb)
   "Get all jobs and execute callback CB with the parsed JSON.
@@ -208,13 +189,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "jobs" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "jobs" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-secrets (props state cb &optional cleanup-cb)
   "Get all secrets and execute callback CB with the parsed JSON.
@@ -225,13 +200,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "secrets" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "secrets" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-get-services (props state cb &optional cleanup-cb)
   "Get all services and execute callback CB with the parsed JSON.
@@ -242,13 +211,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "services" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "services" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-config-view (props state cb &optional cleanup-cb)
   "Get the current configuration and pass it to CB.
@@ -296,13 +259,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "namespaces" "-o" "json")
-                      (lambda (buf)
-                        (let ((json (with-current-buffer buf
-                                      (json-read-from-string (buffer-string)))))
-                          (funcall cb json)))
-                      nil
-                      cleanup-cb))
+  (kubernetes-kubectl-get "namespaces" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-delete-pod (props state pod-name cb &optional error-cb)
   "Delete pod with POD-NAME, then execute CB with the response buffer.

--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -114,105 +114,6 @@ CLEANUP-CB is a function taking no arguments used to release any resources."
                       nil
                       cleanup-cb))
 
-(defun kubernetes-kubectl-get-pods (props state cb &optional cleanup-cb)
-  "Get all pods and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "pods" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-nodes (props state cb &optional cleanup-cb)
-  "Get all nodes and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "nodes" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-configmaps (props state cb &optional cleanup-cb)
-  "Get all configmaps and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "configmaps" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-deployments (props state cb &optional cleanup-cb)
-  "Get all deployments and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "deployments" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-statefulsets (props state cb &optional cleanup-cb)
-  "Get all statefulsets and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "statefulsets" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-ingress (props state cb &optional cleanup-cb)
-  "Get all ingress and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "ingress" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-jobs (props state cb &optional cleanup-cb)
-  "Get all jobs and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "jobs" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-secrets (props state cb &optional cleanup-cb)
-  "Get all secrets and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "secrets" props state cb cleanup-cb))
-
-(defun kubernetes-kubectl-get-services (props state cb &optional cleanup-cb)
-  "Get all services and execute callback CB with the parsed JSON.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "services" props state cb cleanup-cb))
-
 (defun kubernetes-kubectl-config-view (props state cb &optional cleanup-cb)
   "Get the current configuration and pass it to CB.
 
@@ -249,17 +150,6 @@ CB is a function taking the name of the context that was switched to."
                           (string-match (rx bol "Switched to context \"" (group (+? nonl)) "\"." (* space) eol)
                                         (buffer-string))
                           (funcall cb (match-string 1 (buffer-string)))))))
-
-(defun kubernetes-kubectl-get-namespaces (props state cb &optional cleanup-cb)
-  "Get namespaces for the current cluster and pass the parsed response to CB.
-
-PROPS is an alist of functions to inject.  It should normally be passed
-`kubernetes-props'.
-
-STATE is the application state.
-
-CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl-get "namespaces" props state cb cleanup-cb))
 
 (defun kubernetes-kubectl-delete-pod (props state pod-name cb &optional error-cb)
   "Delete pod with POD-NAME, then execute CB with the response buffer.

--- a/kubernetes-namespaces.el
+++ b/kubernetes-namespaces.el
@@ -25,7 +25,7 @@ Update the namespace state if it not set yet."
            (or (kubernetes-state-namespaces state)
                (progn
                  (message "Getting namespaces...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-namespaces)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "namespaces"))))
                    (kubernetes-state-update-namespaces response)
                    response))))
           (namespaces (append namespaces nil))

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -128,7 +128,7 @@ Update the node state if it not set yet."
                  (message "Getting nodes...")
                  (let ((response (kubernetes-kubectl-await-on-async
                                   kubernetes-props state
-                                  #'kubernetes-kubectl-get-nodes)))
+                                  (-partial #'kubernetes-kubectl-get "nodes"))))
                    (kubernetes-state-update-nodes response)
                    response))))
           (nodes (append nodes nil))

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -160,7 +160,7 @@ Update the pod state if it not set yet."
            (or (kubernetes-state-pods state)
                (progn
                  (message "Getting pods...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-pods)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "pods"))))
                    (kubernetes-state-update-pods response)
                    response))))
           (pods (append pods nil))

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -105,7 +105,7 @@ Update the secret state if it not set yet."
            (or (kubernetes-state-secrets state)
                (progn
                  (message "Getting secrets...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-secrets)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "secrets"))))
                    (kubernetes-state-update-secrets response)
                    response))))
           (secrets (append secrets nil))

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -140,7 +140,7 @@ Update the service state if it not set yet."
            (or (kubernetes-state-services state)
                (progn
                  (message "Getting services...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-services)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "services"))))
                    (kubernetes-state-update-services response)
                    response))))
           (services (append services nil))

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -394,12 +394,13 @@
 (defmacro kubernetes-state-define-refreshers (attr &optional canned raw)
   (declare (indent 2))
   (let* ((s-attr (symbol-name attr))
-         (canned (or canned (intern (format "kubernetes-kubectl-get-%s" s-attr)))))
+         (canned (or canned (-partial #'kubernetes-kubectl-get s-attr))))
     `(progn
        (defun ,(intern (format "kubernetes-%s-refresh" s-attr)) (&optional interactive)
          (unless (,(intern (format "kubernetes-process-poll-%s-process-live-p" s-attr)))
            (,(intern (format "kubernetes-process-set-poll-%s-process" s-attr))
-            (,canned
+            (funcall
+             ,canned
              kubernetes-props
              (kubernetes-state)
              (lambda (response)

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -154,7 +154,7 @@ Update the statefulset state if it not set yet."
            (or (kubernetes-state-statefulsets state)
                (progn
                  (message "Getting statefulsets...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-statefulsets)))
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "statefulsets"))))
                    (kubernetes-state-update-statefulsets response)
                    response))))
           (statefulsets (append statefulsets nil))


### PR DESCRIPTION
Relates to #69.

Currently, we define one function for `get`ting all entities of a given resource type, for each of a finite set of resources, e.g. `k8s-kubectl-get-{pods, nodes, ...}`. All of these functions are identical save for the resource type that they retrieve.

As such, we generalize to a single implementation—`k8s-kubectl-get`—that accepts the resource type name and performs the `get` accordingly.

By extension, we rewire all call sites that assume the existence of per-type `get` functions to use the genericized counterpart—most notably the `kubernetes-state-define-refreshers` macro, which currently literally expects functions of those naming pattern to exist.

Similarly, we consolidate unit tests and, finally, remove the granular, per-type `get` functions.