### PR TITLE
Replace resource-specific getters for marked/pending-deletion ConfigMaps w/ genericized counterpart

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -106,7 +106,7 @@
                  (y-or-n-p (format "Delete %s pod%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-pods-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-configmaps state))))
+    (let ((n (length (kubernetes-state--get state 'marked-configmaps))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
+    (let ((n (length (kubernetes-state-marked-ingress state))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-ingress state))))
+    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -28,8 +28,8 @@
 
 (kubernetes-ast-define-component configmap-line (state configmap)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+          (pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'data data
                    'metadata (&alist 'name name 'creationTimestamp created-time))
            configmap)
@@ -84,7 +84,7 @@
 (kubernetes-state-define-refreshers configmaps)
 
 (defun kubernetes-configmaps-delete-marked (state)
-  (let ((names (kubernetes-state-marked-configmaps state)))
+  (let ((names (kubernetes-state--get state 'marked-configmaps)))
     (dolist (name names)
       (kubernetes-state-delete-configmap name)
       (kubernetes-kubectl-delete "configmap" name kubernetes-props state

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
-          (marked-ingress (kubernetes-state-marked-ingress state))
+          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
+          (marked-ingress (kubernetes-state--get state 'marked-ingress))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state-marked-ingress state)))
+  (let ((names (kubernetes-state--get state 'marked-ingress)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
-          (marked-ingress (kubernetes-state--get state 'marked-ingress))
+          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
+          (marked-ingress (kubernetes-state-marked-ingress state))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state--get state 'marked-ingress)))
+  (let ((names (kubernetes-state-marked-ingress state)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -74,8 +74,8 @@
                             (kubernetes-state-resource-name s2))))))
 
 (kubernetes-ast-define-component aggregated-configmap-line (state configmap)
-  (-let* ((pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+  (-let* ((pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'metadata (&alist 'name name )) configmap)
           (line (cond
                  ((member name pending-deletion)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,6 +532,9 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
+(kubernetes-state--define-getter marked-ingress)
+(kubernetes-state--define-getter ingress-pending-deletion)
+
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -423,8 +423,7 @@
               (,(intern (format "kubernetes-state-update-%s" s-attr))
                (json-read-from-string (buffer-string)))
               (-let* (((&alist 'items)
-                       (,(intern (format "kubernetes-state-%s" s-attr))
-                        (kubernetes-state))))
+                       (kubernetes-state--get (kubernetes-state) (quote ,attr))))
                 (seq-map (lambda (item)
                            (-let* (((&alist 'metadata (&alist 'name)) item)) name))
                          items))))
@@ -441,14 +440,13 @@
 
 (defmacro kubernetes-state--define-setter (attr arglist &rest forms-before-update)
   (declare (indent 2))
-  (let ((getter (intern (format "kubernetes-state-%s" attr)))
-        (arg
+  (let ((arg
          (pcase arglist
            (`(,x) x)
            (xs `(list ,@xs)))))
     `(defun ,(intern (format "kubernetes-state-update-%s" attr)) ,arglist
        ,@forms-before-update
-       (let ((prev (,getter (kubernetes-state)))
+       (let ((prev (kubernetes-state--get (kubernetes-state) (quote ,attr)))
              (arg ,arg))
          (kubernetes-state-update ,(intern (format ":update-%s" attr)) ,arg)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -534,9 +534,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-configmaps)
-(kubernetes-state--define-getter configmaps-pending-deletion)
-
 (kubernetes-state--define-getter marked-ingress)
 (kubernetes-state--define-getter ingress-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-ingress)
-(kubernetes-state--define-getter ingress-pending-deletion)
-
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -196,10 +196,8 @@
 
 (defmacro kubernetes-state-marking-tests (resource)
   (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
-
         (get-pending-deletion-fn
          (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
-        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -195,8 +195,11 @@
 ;; Test marking/unmarking/deleting actions
 
 (defmacro kubernetes-state-marking-tests (resource)
-  (let ((get-marks-fn (intern (format "kubernetes-state-marked-%ss" resource)))
-        (get-pending-deletion-fn (intern (format "kubernetes-state-%ss-pending-deletion" resource)))
+  (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
+
+        (get-pending-deletion-fn
+         (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
+        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))


### PR DESCRIPTION
This PR removes the ConfigMap-specific getters for marked ConfigMaps and ConfigMaps pending deletion. In doing so, we also update all callsites to use the resource-generic `kubernetes-state--get` function.