### PR TITLE
Genericize state-getters for default k8s resources

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -106,7 +106,7 @@
                  (y-or-n-p (format "Delete %s pod%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-pods-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-configmaps state))))
+    (let ((n (length (kubernetes-state--get state 'marked-configmaps))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
+    (let ((n (length (kubernetes-state-marked-ingress state))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-ingress state))))
+    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -408,7 +408,7 @@ STATE is the current application state."
   (goto-char (point-min))
 
   ;; State for the context and view should be preserved.
-  (kubernetes-state-update-config (kubernetes-state-config state))
+  (kubernetes-state-update-config (kubernetes-state--get state 'config))
   (kubernetes-state-update-current-namespace ns)
   (kubernetes-state-update-overview-sections (kubernetes-state-overview-sections state))
 
@@ -448,7 +448,7 @@ CONTEXT is the name of a context as a string."
        (kubernetes-state-trigger-redraw)))))
 
 (defun kubernetes--context-names (state)
-  (-let* ((config (or (kubernetes-state-config state) (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-config-view)))
+  (-let* ((config (or (kubernetes-state--get state 'config) (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-config-view)))
           ((&alist 'contexts contexts) config))
     (--map (alist-get 'name it) contexts)))
 

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -312,7 +312,7 @@ Should be invoked via command `kubernetes-exec-popup'."
 
   (let* ((command-args (append (list "exec") (kubernetes-kubectl--flags-from-state (kubernetes-state))
                                args
-                               (when-let (ns (kubernetes-state-current-namespace state))
+                               (when-let (ns (kubernetes-state--get state 'current-namespace))
                                  (list (format "--namespace=%s" ns)))
                                (list pod-name "--" exec-command)))
 
@@ -359,7 +359,7 @@ Should be invoked via command `kubernetes-exec-popup'."
 
   (let* ((command-args (append (list "exec") (kubernetes-kubectl--flags-from-state (kubernetes-state))
                                args
-                               (when-let (ns (kubernetes-state-current-namespace state))
+                               (when-let (ns (kubernetes-state--get state 'current-namespace))
                                  (list (format "--namespace=%s" ns)))
                                (list pod-name "--" exec-command)))
 

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -65,7 +65,7 @@
                       (padding)))))
 
 (kubernetes-ast-define-component configmaps-list (state &optional hidden)
-  (-let (((&alist 'items configmaps) (kubernetes-state-configmaps state))
+  (-let (((&alist 'items configmaps) (kubernetes-state--get state 'configmaps))
          ([fmt labels] kubernetes-configmaps--column-heading))
     `(section (configmaps-container ,hidden)
               (header-with-count "Configmaps" ,configmaps)
@@ -105,7 +105,7 @@ STATE is the current application state.
 
 Update the configmap state if it not set yet."
   (-let* (((&alist 'items configmaps)
-           (or (kubernetes-state-configmaps state)
+           (or (kubernetes-state--get state 'configmaps)
                (progn
                  (message "Getting configmaps...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "configmaps"))))

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -28,8 +28,8 @@
 
 (kubernetes-ast-define-component configmap-line (state configmap)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+          (pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'data data
                    'metadata (&alist 'name name 'creationTimestamp created-time))
            configmap)
@@ -84,7 +84,7 @@
 (kubernetes-state-define-refreshers configmaps)
 
 (defun kubernetes-configmaps-delete-marked (state)
-  (let ((names (kubernetes-state-marked-configmaps state)))
+  (let ((names (kubernetes-state--get state 'marked-configmaps)))
     (dolist (name names)
       (kubernetes-state-delete-configmap name)
       (kubernetes-kubectl-delete "configmap" name kubernetes-props state

--- a/kubernetes-contexts.el
+++ b/kubernetes-contexts.el
@@ -64,7 +64,8 @@
 
 (defalias 'kubernetes-contexts-refresh-now 'kubernetes-config-refresh-now)
 (defalias 'kubernetes-contexts-refresh 'kubernetes-config-refresh-now)
-(defalias 'kubernetes-state-contexts 'kubernetes-state-config)
+(defun kubernetes-state-contexts (state)
+  (kubernetes-state--get state 'config))
 (defalias 'kubernetes-state-update-contexts 'kubernetes-state-update-config)
 
 ;; Displaying config.

--- a/kubernetes-contexts.el
+++ b/kubernetes-contexts.el
@@ -41,7 +41,7 @@
     `(heading (key-value 12 "Context" ,fetching))))
 
 (defun kubernetes-contexts-render (state)
-  (let ((current-namespace (kubernetes-state-current-namespace state))
+  (let ((current-namespace (kubernetes-state--get state 'current-namespace))
         (current-context (kubernetes-state-current-context state)))
 
     `(section (context-container nil)

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -125,7 +125,7 @@
                       (padding)))))
 
 (kubernetes-ast-define-component deployments-list (state &optional hidden)
-  (-let (((state-set-p &as &alist 'items deployments) (kubernetes-state-deployments state))
+  (-let (((state-set-p &as &alist 'items deployments) (kubernetes-state--get state 'deployments))
          ([fmt labels] kubernetes-deployments--column-heading))
     `(section (deployments-container ,hidden)
               (header-with-count "Deployments" ,deployments)
@@ -164,7 +164,7 @@ STATE is the current application state.
 
 Update the deployment state if it not set yet."
   (-let* (((&alist 'items deployments)
-           (or (kubernetes-state-deployments state)
+           (or (kubernetes-state--get state 'deployments)
                (progn
                  (message "Getting deployments...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "deployments"))))

--- a/kubernetes-el-tramp.el
+++ b/kubernetes-el-tramp.el
@@ -31,7 +31,7 @@
   "A tramp-completion function for kubernetes."
   (if (null (kubernetes-state))
       (kubernetes-pods-refresh-now))
-  (-let (((&alist 'items pods) (kubernetes-state-pods (kubernetes-state))))
+  (-let (((&alist 'items pods) (kubernetes-state--get (kubernetes-state) 'pods)))
     (-map (-lambda ((&alist 'metadata (&alist 'name)))
             (list nil name))
           pods)))

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
-          (marked-ingress (kubernetes-state-marked-ingress state))
+          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
+          (marked-ingress (kubernetes-state--get state 'marked-ingress))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state-marked-ingress state)))
+  (let ((names (kubernetes-state--get state 'marked-ingress)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
-          (marked-ingress (kubernetes-state--get state 'marked-ingress))
+          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
+          (marked-ingress (kubernetes-state-marked-ingress state))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state--get state 'marked-ingress)))
+  (let ((names (kubernetes-state-marked-ingress state)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -74,7 +74,7 @@
                       (ingress-detail ,ingress)
                       (padding)))))
 (kubernetes-ast-define-component ingress-list (state &optional hidden)
-  (-let [(&alist 'items ingress) (kubernetes-state-ingress state)]
+  (-let [(&alist 'items ingress) (kubernetes-state--get state 'ingress)]
     `(section (ingress-container ,hidden)
               (header-with-count "Ingress" ,ingress)
               (indent
@@ -107,7 +107,7 @@ STATE is the current application state.
 
 Update the ingress state if it not set yet."
   (-let* (((&alist 'items ingress)
-           (or (kubernetes-state-ingress state)
+           (or (kubernetes-state--get state 'ingress)
                (progn
                  (message "Getting ingress...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "ingress"))))

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -110,7 +110,7 @@
                         (job-detail ,state ,pod ,job))))))
 
 (kubernetes-ast-define-component jobs-list (state &optional hidden)
-  (-let (((state-set-p &as &alist 'items jobs) (kubernetes-state-jobs state))
+  (-let (((state-set-p &as &alist 'items jobs) (kubernetes-state--get state 'jobs))
          ([fmt labels] kubernetes-jobs--column-heading))
     `(section (jobs-container ,hidden)
               (header-with-count "Jobs" ,jobs)
@@ -149,7 +149,7 @@ STATE is the current application state.
 
 Update the job state if it not set yet."
   (-let* (((&alist 'items jobs)
-           (or (kubernetes-state-jobs state)
+           (or (kubernetes-state--get state 'jobs)
                (progn
                  (message "Getting jobs...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "jobs"))))

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -29,7 +29,7 @@
                             'startTime start-time
                             'completionTime completion-time))
            job)
-          ((&alist 'items pods) (kubernetes-state-pods state)))
+          ((&alist 'items pods) (kubernetes-state--get state 'pods)))
 
     `((section (namespace nil)
                (nav-prop (:namespace-name ,ns)
@@ -95,7 +95,7 @@
 
 (defun kubernetes-jobs--lookup-pod-for-job (job state)
   (-let* (((&alist 'metadata (&alist 'labels (&alist 'job-name job-name))) job)
-          ((&alist 'items items) (kubernetes-state-pods state)))
+          ((&alist 'items items) (kubernetes-state--get state 'pods)))
     (seq-find (lambda (pod)
                 (let ((pod-name (kubernetes-state-resource-name pod)))
                   (string-prefix-p job-name pod-name)))

--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -29,7 +29,7 @@
         (kubernetes-props-message props (string-trim-right last-error))))))
 
 (defun kubernetes-kubectl--flags-from-state (state)
-  (append (when-let (ns (kubernetes-state-current-namespace state))
+  (append (when-let (ns (kubernetes-state--get state 'current-namespace))
             (list (format "--namespace=%s" ns)))
           (kubernetes-state-kubectl-flags state)))
 

--- a/kubernetes-labels.el
+++ b/kubernetes-labels.el
@@ -15,7 +15,7 @@
 ;; Component
 
 (kubernetes-ast-define-component labelled-pods-list (state)
-  (-let* ((query (kubernetes-state-label-query state))
+  (-let* ((query (kubernetes-state--get state 'label-query))
           ((&alist 'items pods) (kubernetes-state--get state 'pods))
           (matches (nreverse (seq-reduce
                               (lambda (acc pod)

--- a/kubernetes-labels.el
+++ b/kubernetes-labels.el
@@ -16,7 +16,7 @@
 
 (kubernetes-ast-define-component labelled-pods-list (state)
   (-let* ((query (kubernetes-state-label-query state))
-          ((&alist 'items pods) (kubernetes-state-pods state))
+          ((&alist 'items pods) (kubernetes-state--get state 'pods))
           (matches (nreverse (seq-reduce
                               (lambda (acc pod)
                                 (if (equal query (kubernetes-state-resource-label pod))
@@ -70,7 +70,7 @@
 
 LABEL-QUERY is a string used to match pods."
   (interactive
-   (-let* (((&alist 'items pods) (kubernetes-state-pods (kubernetes-state)))
+   (-let* (((&alist 'items pods) (kubernetes-state--get (kubernetes-state) 'pods))
            (labels (-non-nil (-uniq (seq-map #'kubernetes-state-resource-label pods)))))
      (list (completing-read "Label: " labels))))
 

--- a/kubernetes-logs.el
+++ b/kubernetes-logs.el
@@ -88,7 +88,7 @@ STATE is the current application state"
            (transient-args 'kubernetes-logs)
            state)))
   (let ((args (append (list "logs") args (list pod-name) (kubernetes-kubectl--flags-from-state (kubernetes-state))
-                      (when-let (ns (kubernetes-state-current-namespace state))
+                      (when-let (ns (kubernetes-state--get state 'current-namespace))
                         (list (format "--namespace=%s" ns))))))
     (with-current-buffer (kubernetes-utils-process-buffer-start kubernetes-logs-buffer-name #'kubernetes-logs-mode kubernetes-kubectl-executable args)
       (select-window (display-buffer (current-buffer))))))

--- a/kubernetes-namespaces.el
+++ b/kubernetes-namespaces.el
@@ -22,7 +22,7 @@ STATE is the current application state.
 
 Update the namespace state if it not set yet."
   (-let* (((&alist 'items namespaces)
-           (or (kubernetes-state-namespaces state)
+           (or (kubernetes-state--get state 'namespaces)
                (progn
                  (message "Getting namespaces...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "namespaces"))))

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -97,7 +97,7 @@
                       (padding)))))
 
 (kubernetes-ast-define-component nodes-list (state &optional hidden)
-  (-let (((&alist 'items nodes) (kubernetes-state-nodes state))
+  (-let (((&alist 'items nodes) (kubernetes-state--get state 'nodes))
          ([fmt labels] kubernetes-nodes--column-heading))
     `(section (nodes-container ,hidden)
               (header-with-count "Nodes" ,nodes)
@@ -123,7 +123,7 @@ STATE is the current application state.
 
 Update the node state if it not set yet."
   (-let* (((&alist 'items nodes)
-           (or (kubernetes-state-nodes state)
+           (or (kubernetes-state--get state 'nodes)
                (progn
                  (message "Getting nodes...")
                  (let ((response (kubernetes-kubectl-await-on-async

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -30,7 +30,7 @@
 ;; Configmaps
 
 (defun kubernetes-overview--referenced-configmaps (state pod)
-  (-let* (((&alist 'items configmaps) (kubernetes-state-configmaps state))
+  (-let* (((&alist 'items configmaps) (kubernetes-state--get state 'configmaps))
           (configmaps (append configmaps nil))
           ((&alist 'spec (&alist 'volumes volumes 'containers containers)) pod)
 
@@ -126,14 +126,14 @@
               matches)))
 
 (defun kubernetes-overview--secrets-for-deployment (state pods)
-  (-let* (((&alist 'items secrets) (kubernetes-state-secrets state))
+  (-let* (((&alist 'items secrets) (kubernetes-state--get state 'secrets))
           (secrets (append secrets nil)))
     (-non-nil (-uniq (seq-mapcat (lambda (pod)
                                    (kubernetes-overview--referenced-secrets secrets pod))
                                  pods)))))
 
 (defun kubernetes-overview--secrets-for-statefulset (state pods)
-  (-let* (((&alist 'items secrets) (kubernetes-state-secrets state))
+  (-let* (((&alist 'items secrets) (kubernetes-state--get state 'secrets))
           (secrets (append secrets nil)))
     (-non-nil (-uniq (seq-mapcat (lambda (pod)
                                    (kubernetes-overview--referenced-secrets secrets pod))
@@ -293,9 +293,9 @@
 ;; Main Components
 
 (kubernetes-ast-define-component aggregated-view (state &optional hidden)
-  (-let [(state-set-p &as &alist 'items deployments) (kubernetes-state-deployments state)]
+  (-let [(state-set-p &as &alist 'items deployments) (kubernetes-state--get state 'deployments)]
     (-let (((state-set-p &as &alist 'items statefulsets)
-            (kubernetes-state-statefulsets state))
+            (kubernetes-state--get state 'statefulsets))
            ([fmt0 labels0] kubernetes-statefulsets--column-heading)
            ([fmt1 labels1] kubernetes-deployments--column-heading))
       `(section (ubercontainer, nil)

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -74,8 +74,8 @@
                             (kubernetes-state-resource-name s2))))))
 
 (kubernetes-ast-define-component aggregated-configmap-line (state configmap)
-  (-let* ((pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+  (-let* ((pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'metadata (&alist 'name name )) configmap)
           (line (cond
                  ((member name pending-deletion)

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -165,7 +165,7 @@
 
 (defun kubernetes-overview--pods-for-deployment (state deployment)
   (-let* (((&alist 'spec (&alist 'selector (&alist 'matchLabels selectors))) deployment)
-          ((&alist 'items pods) (kubernetes-state-pods state))
+          ((&alist 'items pods) (kubernetes-state--get state 'pods))
           (pods (append pods nil)))
     (nreverse (seq-reduce
                (lambda (acc pod)
@@ -179,7 +179,7 @@
 
 (defun kubernetes-overview--pods-for-statefulset (state statefulset)
   (-let* (((&alist 'spec (&alist 'selector (&alist 'matchLabels (&alist 'name selector-name)))) statefulset)
-          ((&alist 'items pods) (kubernetes-state-pods state))
+          ((&alist 'items pods) (kubernetes-state--get state 'pods))
           (pods (append pods nil)))
     (nreverse (seq-reduce
                (lambda (acc pod)
@@ -213,7 +213,7 @@
                             (heading "Match Expressions")
                             (indent ,(kubernetes-yaml-render match-expressions))))
                (key-value 12 "Replicas" ,(format "%s" (or replicas 1)))
-               (columnar-loading-container ,(kubernetes-state-pods state) nil
+               (columnar-loading-container ,(kubernetes-state--get state 'pods) nil
                                            ,@(seq-map (lambda (pod) `(pod-line ,state ,pod)) pods)))
               (padding))))
 

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -130,7 +130,7 @@
       (equal phase "Succeeded"))))
 
 (kubernetes-ast-define-component pods-list (state &optional hidden)
-  (-let (((&alist 'items pods) (kubernetes-state-pods state))
+  (-let (((&alist 'items pods) (kubernetes-state--get state 'pods))
          ([fmt labels] kubernetes-pods--column-heading))
     `(section (pods-container ,hidden)
               (header-with-count "Pods" ,pods)
@@ -157,7 +157,7 @@ STATE is the current application state.
 
 Update the pod state if it not set yet."
   (-let* (((&alist 'items pods)
-           (or (kubernetes-state-pods state)
+           (or (kubernetes-state--get state 'pods)
                (progn
                  (message "Getting pods...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "pods"))))

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -63,7 +63,7 @@
                       (padding)))))
 
 (kubernetes-ast-define-component secrets-list (state &optional hidden)
-  (-let (((&alist 'items secrets) (kubernetes-state-secrets state))
+  (-let (((&alist 'items secrets) (kubernetes-state--get state 'secrets))
          ([fmt labels] kubernetes-secrets--column-heading))
     `(section (secrets-container ,hidden)
               (header-with-count "Secrets" ,secrets)
@@ -102,7 +102,7 @@ STATE is the current application state.
 
 Update the secret state if it not set yet."
   (-let* (((&alist 'items secrets)
-           (or (kubernetes-state-secrets state)
+           (or (kubernetes-state--get state 'secrets)
                (progn
                  (message "Getting secrets...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "secrets"))))

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -98,7 +98,7 @@
                       (padding)))))
 
 (kubernetes-ast-define-component services-list (state &optional hidden)
-  (-let (((services-response &as &alist 'items services) (kubernetes-state-services state))
+  (-let (((services-response &as &alist 'items services) (kubernetes-state--get state 'services))
          ([fmt labels] kubernetes-services--column-heading))
     `(section (services-container ,hidden)
               (header-with-count "Services" ,services)
@@ -137,7 +137,7 @@ STATE is the current application state.
 
 Update the service state if it not set yet."
   (-let* (((&alist 'items services)
-           (or (kubernetes-state-services state)
+           (or (kubernetes-state--get state 'services)
                (progn
                  (message "Getting services...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "services"))))

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,6 +532,9 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
+(kubernetes-state--define-getter marked-ingress)
+(kubernetes-state--define-getter ingress-pending-deletion)
+
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -423,8 +423,7 @@
               (,(intern (format "kubernetes-state-update-%s" s-attr))
                (json-read-from-string (buffer-string)))
               (-let* (((&alist 'items)
-                       (,(intern (format "kubernetes-state-%s" s-attr))
-                        (kubernetes-state))))
+                       (kubernetes-state--get (kubernetes-state) (quote ,attr))))
                 (seq-map (lambda (item)
                            (-let* (((&alist 'metadata (&alist 'name)) item)) name))
                          items))))
@@ -441,14 +440,13 @@
 
 (defmacro kubernetes-state--define-setter (attr arglist &rest forms-before-update)
   (declare (indent 2))
-  (let ((getter (intern (format "kubernetes-state-%s" attr)))
-        (arg
+  (let ((arg
          (pcase arglist
            (`(,x) x)
            (xs `(list ,@xs)))))
     `(defun ,(intern (format "kubernetes-state-update-%s" attr)) ,arglist
        ,@forms-before-update
-       (let ((prev (,getter (kubernetes-state)))
+       (let ((prev (kubernetes-state--get (kubernetes-state) (quote ,attr)))
              (arg ,arg))
          (kubernetes-state-update ,(intern (format ":update-%s" attr)) ,arg)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -467,7 +467,7 @@
     (namespace)
   (cl-assert (stringp namespace)))
 
-(kubernetes-state--define-accessors pods (pods)
+(kubernetes-state--define-setter pods (pods)
   (cl-assert (listp pods)))
 
 (kubernetes-state--define-accessors ingress (ingress)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -534,9 +534,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-configmaps)
-(kubernetes-state--define-getter configmaps-pending-deletion)
-
 (kubernetes-state--define-getter marked-ingress)
 (kubernetes-state--define-getter ingress-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-ingress)
-(kubernetes-state--define-getter ingress-pending-deletion)
-
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -470,37 +470,37 @@
 (kubernetes-state--define-setter pods (pods)
   (cl-assert (listp pods)))
 
-(kubernetes-state--define-accessors ingress (ingress)
+(kubernetes-state--define-setter ingress (ingress)
   (cl-assert (listp ingress)))
 
-(kubernetes-state--define-accessors jobs (jobs)
+(kubernetes-state--define-setter jobs (jobs)
   (cl-assert (listp jobs)))
 
-(kubernetes-state--define-accessors configmaps (configmaps)
+(kubernetes-state--define-setter configmaps (configmaps)
   (cl-assert (listp configmaps)))
 
-(kubernetes-state--define-accessors secrets (secrets)
+(kubernetes-state--define-setter secrets (secrets)
   (cl-assert (listp secrets)))
 
-(kubernetes-state--define-accessors services (services)
+(kubernetes-state--define-setter services (services)
   (cl-assert (listp services)))
 
-(kubernetes-state--define-accessors deployments (deployments)
+(kubernetes-state--define-setter deployments (deployments)
   (cl-assert (listp deployments)))
 
-(kubernetes-state--define-accessors nodes (nodes)
+(kubernetes-state--define-setter nodes (nodes)
   (cl-assert (listp nodes)))
 
-(kubernetes-state--define-accessors statefulsets (statefulsets)
+(kubernetes-state--define-setter statefulsets (statefulsets)
   (cl-assert (listp statefulsets)))
 
-(kubernetes-state--define-accessors namespaces (namespaces)
+(kubernetes-state--define-setter namespaces (namespaces)
   (cl-assert (listp namespaces)))
 
-(kubernetes-state--define-accessors config (config)
+(kubernetes-state--define-setter config (config)
   (cl-assert (listp config)))
 
-(kubernetes-state--define-accessors label-query (label-name)
+(kubernetes-state--define-setter label-query (label-name)
   (cl-assert (stringp label-name)))
 
 (defun kubernetes-state-overview-sections (state)
@@ -628,7 +628,7 @@ pod, secret, configmap, etc."
     label))
 
 (defun kubernetes-state-current-context (state)
-  (when-let (config (kubernetes-state-config state))
+  (when-let (config (kubernetes-state--get state 'config))
     (kubernetes-state--lookup-current-context config)))
 
 (defun kubernetes-state-clear-error-if-stale (error-display-time)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -462,7 +462,9 @@
      (kubernetes-state--define-getter ,attr)
      (kubernetes-state--define-setter ,attr ,arglist ,@forms-before-update)))
 
-(kubernetes-state--define-accessors current-namespace (namespace)
+(kubernetes-state--define-setter
+    current-namespace
+    (namespace)
   (cl-assert (stringp namespace)))
 
 (kubernetes-state--define-accessors pods (pods)

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -112,7 +112,7 @@
 
 (kubernetes-ast-define-component statefulsets-list (state &optional hidden)
   (-let (((state-set-p &as &alist 'items statefulsets)
-          (kubernetes-state-statefulsets state))
+          (kubernetes-state--get state 'statefulsets))
          ([fmt labels] kubernetes-statefulsets--column-heading))
     `(section (statefulsets-container ,hidden)
               (header-with-count "Statefulsets" ,statefulsets)
@@ -151,7 +151,7 @@ STATE is the current application state.
 
 Update the statefulset state if it not set yet."
   (-let* (((&alist 'items statefulsets)
-           (or (kubernetes-state-statefulsets state)
+           (or (kubernetes-state--get state 'statefulsets)
                (progn
                  (message "Getting statefulsets...")
                  (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state (-partial #'kubernetes-kubectl-get "statefulsets"))))

--- a/test/kubernetes-pod-line-test.el
+++ b/test/kubernetes-pod-line-test.el
@@ -10,7 +10,7 @@
 
 (ert-deftest kubernetes-pod-line-test--pod-line-ok-p ()
   (let* ((state `((pods . ,sample-get-pods-response)))
-         (pods (kubernetes-state-pods state))
+         (pods (kubernetes-state--get state 'pods))
          (pod (aref (alist-get 'items pods) 0)))
     (should-not (null (kubernetes-pod-line-ok-p pod)))))
 

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -196,10 +196,8 @@
 
 (defmacro kubernetes-state-marking-tests (resource)
   (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
-
         (get-pending-deletion-fn
          (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
-        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -195,8 +195,11 @@
 ;; Test marking/unmarking/deleting actions
 
 (defmacro kubernetes-state-marking-tests (resource)
-  (let ((get-marks-fn (intern (format "kubernetes-state-marked-%ss" resource)))
-        (get-pending-deletion-fn (intern (format "kubernetes-state-%ss-pending-deletion" resource)))
+  (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
+
+        (get-pending-deletion-fn
+         (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
+        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -155,14 +155,14 @@
   (let ((kubernetes-state--current-state nil))
     (kubernetes-state-update-config sample-get-config-response)
     (should (kubernetes-state-config (kubernetes-state)))
-    (should (kubernetes-state-current-namespace (kubernetes-state)))))
+    (should (kubernetes-state--get (kubernetes-state) 'current-namespace))))
 
 (ert-deftest kubernetes-state-test--update-config-ignores-current-namespace-if-set ()
   (let ((kubernetes-state--current-state nil))
     (kubernetes-state-update-current-namespace "foo")
     (kubernetes-state-update-config sample-get-config-response)
     (should (kubernetes-state-config (kubernetes-state)))
-    (should (equal "foo" (kubernetes-state-current-namespace (kubernetes-state))))))
+    (should (equal "foo" (kubernetes-state--get (kubernetes-state) 'current-namespace)))))
 
 (ert-deftest kubernetes-state-test--kubectl-flags-initialized-using-config-popup-vars ()
   (let ((kubernetes-kubectl-flags '("--foo=bar" "-x")))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -154,14 +154,14 @@
 (ert-deftest kubernetes-state-test--update-config-also-updates-current-namespace-if-empty ()
   (let ((kubernetes-state--current-state nil))
     (kubernetes-state-update-config sample-get-config-response)
-    (should (kubernetes-state-config (kubernetes-state)))
+    (should (kubernetes-state--get (kubernetes-state) 'config))
     (should (kubernetes-state--get (kubernetes-state) 'current-namespace))))
 
 (ert-deftest kubernetes-state-test--update-config-ignores-current-namespace-if-set ()
   (let ((kubernetes-state--current-state nil))
     (kubernetes-state-update-current-namespace "foo")
     (kubernetes-state-update-config sample-get-config-response)
-    (should (kubernetes-state-config (kubernetes-state)))
+    (should (kubernetes-state--get (kubernetes-state) 'config))
     (should (equal "foo" (kubernetes-state--get (kubernetes-state) 'current-namespace)))))
 
 (ert-deftest kubernetes-state-test--kubectl-flags-initialized-using-config-popup-vars ()


### PR DESCRIPTION
Relates to #69.

This PR removes the resource-specific getters for default k8s resources, e.g. pods and deployments, in favor of the generic counterpart introduced in #200. 