### PR TITLE
Genericize state-getters for marked resources

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -106,7 +106,7 @@
                  (y-or-n-p (format "Delete %s pod%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-pods-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-configmaps state))))
+    (let ((n (length (kubernetes-state--get state 'marked-configmaps))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
+    (let ((n (length (kubernetes-state-marked-ingress state))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -101,7 +101,7 @@
   "Action all marked items in the buffer."
   (interactive)
   (let ((state (kubernetes-state)))
-    (let ((n (length (kubernetes-state-marked-pods state))))
+    (let ((n (length (kubernetes-state--get state 'marked-pods))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s pod%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-pods-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -131,7 +131,7 @@
                  (y-or-n-p (format "Delete %s statefulsets%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-statefulsets-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-jobs state))))
+    (let ((n (length (kubernetes-state--get state 'marked-jobs))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s job%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-jobs-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -111,7 +111,7 @@
                  (y-or-n-p (format "Delete %s configmap%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-configmaps-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-ingress state))))
+    (let ((n (length (kubernetes-state--get state 'marked-ingress))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -136,7 +136,7 @@
                  (y-or-n-p (format "Delete %s job%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-jobs-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-services state))))
+    (let ((n (length (kubernetes-state--get state 'marked-services))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s service%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-services-delete-marked state))))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -126,7 +126,7 @@
                  (y-or-n-p (format "Delete %s deployment%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-deployments-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-statefulsets state))))
+    (let ((n (length (kubernetes-state--get state 'marked-statefulsets))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s statefulsets%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-statefulsets-delete-marked state)))

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -116,7 +116,7 @@
                  (y-or-n-p (format "Delete %s ingress%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-ingress-delete-marked state)))
 
-    (let ((n (length (kubernetes-state-marked-secrets state))))
+    (let ((n (length (kubernetes-state--get state 'marked-secrets))))
       (when (and (not (zerop n))
                  (y-or-n-p (format "Delete %s secret%s? " n (if (equal 1 n) "" "s"))))
         (kubernetes-secrets-delete-marked state)))

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -27,7 +27,7 @@
       (key-value 12 "Created" ,time))))
 
 (kubernetes-ast-define-component configmap-line (state configmap)
-  (-let* ((current-time (kubernetes-state-current-time state))
+  (-let* ((current-time (kubernetes-state--get state 'current-time))
           (pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
           (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'data data

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -28,8 +28,8 @@
 
 (kubernetes-ast-define-component configmap-line (state configmap)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+          (pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'data data
                    'metadata (&alist 'name name 'creationTimestamp created-time))
            configmap)
@@ -84,7 +84,7 @@
 (kubernetes-state-define-refreshers configmaps)
 
 (defun kubernetes-configmaps-delete-marked (state)
-  (let ((names (kubernetes-state-marked-configmaps state)))
+  (let ((names (kubernetes-state--get state 'marked-configmaps)))
     (dolist (name names)
       (kubernetes-state-delete-configmap name)
       (kubernetes-kubectl-delete "configmap" name kubernetes-props state

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -45,7 +45,7 @@
       (key-value 12 "Created" ,time))))
 
 (kubernetes-ast-define-component deployment-line (state deployment)
-  (-let* ((current-time (kubernetes-state-current-time state))
+  (-let* ((current-time (kubernetes-state--get state 'current-time))
           (pending-deletion (kubernetes-state--get state 'deployments-pending-deletion))
           (marked-deployments (kubernetes-state--get state 'marked-deployments))
 

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -46,8 +46,8 @@
 
 (kubernetes-ast-define-component deployment-line (state deployment)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-deployments-pending-deletion state))
-          (marked-deployments (kubernetes-state-marked-deployments state))
+          (pending-deletion (kubernetes-state--get state 'deployments-pending-deletion))
+          (marked-deployments (kubernetes-state--get state 'marked-deployments))
 
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
 
@@ -143,7 +143,7 @@
 (kubernetes-state-define-refreshers deployments)
 
 (defun kubernetes-deployments-delete-marked (state)
-  (let ((names (kubernetes-state-marked-deployments state)))
+  (let ((names (kubernetes-state--get state 'marked-deployments)))
     (dolist (name names)
       (kubernetes-state-delete-deployment name)
       (kubernetes-kubectl-delete "deployment" name kubernetes-props state

--- a/kubernetes-errors.el
+++ b/kubernetes-errors.el
@@ -8,7 +8,7 @@
 (require 'kubernetes-state)
 
 (defun kubernetes-errors-render (state)
-  (-when-let* (((&alist 'message message 'command command) (kubernetes-state-last-error state))
+  (-when-let* (((&alist 'message message 'command command) (kubernetes-state--get state 'last-error))
                (message-paragraph
                 (with-temp-buffer
                   (insert message)

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
-          (marked-ingress (kubernetes-state-marked-ingress state))
+          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
+          (marked-ingress (kubernetes-state--get state 'marked-ingress))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state-marked-ingress state)))
+  (let ((names (kubernetes-state--get state 'marked-ingress)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -29,8 +29,8 @@
 
 (kubernetes-ast-define-component ingress-line (state ingress)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state--get state 'ingress-pending-deletion))
-          (marked-ingress (kubernetes-state--get state 'marked-ingress))
+          (pending-deletion (kubernetes-state-ingress-pending-deletion state))
+          (marked-ingress (kubernetes-state-marked-ingress state))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'rules ingress-rules)
                    'status (&alist 'loadBalancer (&alist 'ingress ingress-lb-list)))
@@ -87,7 +87,7 @@
 (kubernetes-state-define-refreshers ingress)
 
 (defun kubernetes-ingress-delete-marked (state)
-  (let ((names (kubernetes-state--get state 'marked-ingress)))
+  (let ((names (kubernetes-state-marked-ingress state)))
     (dolist (name names)
       (kubernetes-state-delete-ingress name)
       (kubernetes-kubectl-delete "ingress" name kubernetes-props state

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -54,8 +54,8 @@
 
 (kubernetes-ast-define-component job-line (state pod job)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-jobs-pending-deletion state))
-          (marked-jobs (kubernetes-state-marked-jobs state))
+          (pending-deletion (kubernetes-state--get state 'jobs-pending-deletion))
+          (marked-jobs (kubernetes-state--get state 'marked-jobs))
 
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'status (&alist 'succeeded successful
@@ -128,7 +128,7 @@
 (kubernetes-state-define-refreshers jobs)
 
 (defun kubernetes-jobs-delete-marked (state)
-  (let ((names (kubernetes-state-marked-jobs state)))
+  (let ((names (kubernetes-state--get state 'marked-jobs)))
     (dolist (name names)
       (kubernetes-state-delete-job name)
       (kubernetes-kubectl-delete "job" name kubernetes-props state

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -74,8 +74,8 @@
                             (kubernetes-state-resource-name s2))))))
 
 (kubernetes-ast-define-component aggregated-configmap-line (state configmap)
-  (-let* ((pending-deletion (kubernetes-state-configmaps-pending-deletion state))
-          (marked-configmaps (kubernetes-state-marked-configmaps state))
+  (-let* ((pending-deletion (kubernetes-state--get state 'configmaps-pending-deletion))
+          (marked-configmaps (kubernetes-state--get state 'marked-configmaps))
           ((&alist 'metadata (&alist 'name name )) configmap)
           (line (cond
                  ((member name pending-deletion)

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -140,8 +140,8 @@
                                  pods)))))
 
 (kubernetes-ast-define-component aggregated-secret-line (state secret)
-  (-let* ((pending-deletion (kubernetes-state-secrets-pending-deletion state))
-          (marked-secrets (kubernetes-state-marked-secrets state))
+  (-let* ((pending-deletion (kubernetes-state--get state 'secrets-pending-deletion))
+          (marked-secrets (kubernetes-state--get state 'marked-secrets))
           ((&alist 'metadata (&alist 'name name )) secret)
           (line (cond
                  ((member name pending-deletion)

--- a/kubernetes-pod-line.el
+++ b/kubernetes-pod-line.el
@@ -16,8 +16,8 @@
                                        "succeeded"))))))
 
 (kubernetes-ast-define-component pod-line (state pod)
-  (-let* ((marked-pods (kubernetes-state-marked-pods state))
-          (pending-deletion (kubernetes-state-pods-pending-deletion state))
+  (-let* ((marked-pods (kubernetes-state--get state 'marked-pods))
+          (pending-deletion (kubernetes-state--get state 'pods-pending-deletion))
           ((&alist 'metadata (&alist 'name name) 'status (&alist 'containerStatuses containers 'phase phase)) pod)
           ([(&alist 'state pod-state)] containers)
           (pod-state (or (alist-get 'reason (alist-get 'waiting pod-state)) phase))

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -50,8 +50,8 @@
 
 (kubernetes-ast-define-component pod-view-line (state pod)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (marked-pods (kubernetes-state-marked-pods state))
-          (pending-deletion (kubernetes-state-pods-pending-deletion state))
+          (marked-pods (kubernetes-state--get state 'marked-pods))
+          (pending-deletion (kubernetes-state--get state 'pods-pending-deletion))
           ((&alist 'metadata (&alist 'name name)
                    'status (&alist 'containerStatuses containers
                                    'startTime start-time
@@ -168,7 +168,7 @@ Update the pod state if it not set yet."
     (completing-read "Pod: " names nil t)))
 
 (defun kubernetes-pods-delete-marked (state)
-  (let ((names (kubernetes-state-marked-pods state)))
+  (let ((names (kubernetes-state--get state 'marked-pods)))
     (dolist (name names)
       (kubernetes-state-delete-pod name)
       (kubernetes-kubectl-delete "pod" name kubernetes-props state

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -49,7 +49,7 @@
 
 
 (kubernetes-ast-define-component pod-view-line (state pod)
-  (-let* ((current-time (kubernetes-state-current-time state))
+  (-let* ((current-time (kubernetes-state--get state 'current-time))
           (marked-pods (kubernetes-state--get state 'marked-pods))
           (pending-deletion (kubernetes-state--get state 'pods-pending-deletion))
           ((&alist 'metadata (&alist 'name name)

--- a/kubernetes-props.el
+++ b/kubernetes-props.el
@@ -7,7 +7,7 @@
     (update-last-error . kubernetes-state-update-last-error)
     (overview-buffer-selected-p . kubernetes-utils-overview-buffer-selected-p)
     (get-last-error . (lambda ()
-                        (kubernetes-state-last-error (kubernetes-state)))))
+                        (kubernetes-state--get (kubernetes-state) 'last-error))))
   "Variable used to inject functions across modules.")
 
 (defun kubernetes-props-update-last-error (props message command time)

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -27,8 +27,8 @@
 
 (kubernetes-ast-define-component secret-line (state secret)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-secrets-pending-deletion state))
-          (marked-secrets (kubernetes-state-marked-secrets state))
+          (pending-deletion (kubernetes-state--get state 'secrets-pending-deletion))
+          (marked-secrets (kubernetes-state--get state 'marked-secrets))
           ((&alist 'data data 'metadata (&alist 'name name 'creationTimestamp created-time))
            secret)
           ([fmt] kubernetes-secrets--column-heading)
@@ -81,7 +81,7 @@
 (kubernetes-state-define-refreshers secrets)
 
 (defun kubernetes-secrets-delete-marked (state)
-  (let ((names (kubernetes-state-marked-secrets state)))
+  (let ((names (kubernetes-state--get state 'marked-secrets)))
     (dolist (name names)
       (kubernetes-state-delete-secret name)
       (kubernetes-kubectl-delete "secret" name kubernetes-props state

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -26,7 +26,7 @@
       (key-value 12 "Created" ,time))))
 
 (kubernetes-ast-define-component secret-line (state secret)
-  (-let* ((current-time (kubernetes-state-current-time state))
+  (-let* ((current-time (kubernetes-state--get state 'current-time))
           (pending-deletion (kubernetes-state--get state 'secrets-pending-deletion))
           (marked-secrets (kubernetes-state--get state 'marked-secrets))
           ((&alist 'data data 'metadata (&alist 'name name 'creationTimestamp created-time))

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -56,8 +56,8 @@
 
 (kubernetes-ast-define-component service-line (state service)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-services-pending-deletion state))
-          (marked-services (kubernetes-state-marked-services state))
+          (pending-deletion (kubernetes-state--get state 'services-pending-deletion))
+          (marked-services (kubernetes-state--get state 'marked-services))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
                    'spec (&alist 'clusterIP internal-ip
                                  'externalIPs external-ips))
@@ -116,7 +116,7 @@
 (kubernetes-state-define-refreshers services)
 
 (defun kubernetes-services-delete-marked (state)
-  (let ((names (kubernetes-state-marked-services state)))
+  (let ((names (kubernetes-state--get state 'marked-services)))
     (dolist (name names)
       (kubernetes-state-delete-service name)
       (kubernetes-kubectl-delete "service" name kubernetes-props state

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,6 +532,9 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
+(kubernetes-state--define-getter marked-ingress)
+(kubernetes-state--define-getter ingress-pending-deletion)
+
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-pods)
-(kubernetes-state--define-getter pods-pending-deletion)
-
 (kubernetes-state--define-getter marked-secrets)
 (kubernetes-state--define-getter secrets-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -423,8 +423,7 @@
               (,(intern (format "kubernetes-state-update-%s" s-attr))
                (json-read-from-string (buffer-string)))
               (-let* (((&alist 'items)
-                       (,(intern (format "kubernetes-state-%s" s-attr))
-                        (kubernetes-state))))
+                       (kubernetes-state--get (kubernetes-state) (quote ,attr))))
                 (seq-map (lambda (item)
                            (-let* (((&alist 'metadata (&alist 'name)) item)) name))
                          items))))
@@ -441,14 +440,13 @@
 
 (defmacro kubernetes-state--define-setter (attr arglist &rest forms-before-update)
   (declare (indent 2))
-  (let ((getter (intern (format "kubernetes-state-%s" attr)))
-        (arg
+  (let ((arg
          (pcase arglist
            (`(,x) x)
            (xs `(list ,@xs)))))
     `(defun ,(intern (format "kubernetes-state-update-%s" attr)) ,arglist
        ,@forms-before-update
-       (let ((prev (,getter (kubernetes-state)))
+       (let ((prev (kubernetes-state--get (kubernetes-state) (quote ,attr)))
              (arg ,arg))
          (kubernetes-state-update ,(intern (format ":update-%s" attr)) ,arg)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -534,9 +534,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-configmaps)
-(kubernetes-state--define-getter configmaps-pending-deletion)
-
 (kubernetes-state--define-getter marked-ingress)
 (kubernetes-state--define-getter ingress-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-statefulsets)
-(kubernetes-state--define-getter statefulsets-pending-deletion)
-
 (kubernetes-state--define-getter last-error)
 
 (defun kubernetes-state-update-last-error (message command time)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-deployments)
-(kubernetes-state--define-getter deployments-pending-deletion)
-
 (kubernetes-state--define-getter marked-statefulsets)
 (kubernetes-state--define-getter statefulsets-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-ingress)
-(kubernetes-state--define-getter ingress-pending-deletion)
-
 (kubernetes-state--define-getter marked-jobs)
 (kubernetes-state--define-getter jobs-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-secrets)
-(kubernetes-state--define-getter secrets-pending-deletion)
-
 (kubernetes-state--define-getter marked-services)
 (kubernetes-state--define-getter services-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-jobs)
-(kubernetes-state--define-getter jobs-pending-deletion)
-
 (kubernetes-state--define-getter marked-pods)
 (kubernetes-state--define-getter pods-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,9 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter marked-services)
-(kubernetes-state--define-getter services-pending-deletion)
-
 (kubernetes-state--define-getter marked-deployments)
 (kubernetes-state--define-getter deployments-pending-deletion)
 

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -532,8 +532,6 @@
   (cl-assert (-all? #'stringp flags))
   (setq kubernetes-kubectl-flags flags))
 
-(kubernetes-state--define-getter last-error)
-
 (defun kubernetes-state-update-last-error (message command time)
   (cl-assert (stringp message))
   (cl-assert (stringp command))
@@ -609,7 +607,7 @@ pod, secret, configmap, etc."
     (kubernetes-state--lookup-current-context config)))
 
 (defun kubernetes-state-clear-error-if-stale (error-display-time)
-  (-when-let ((&alist 'time err-time) (kubernetes-state-last-error (kubernetes-state)))
+  (-when-let ((&alist 'time err-time) (kubernetes-state--get (kubernetes-state) 'last-error))
     (when (< error-display-time
              (- (time-to-seconds) (time-to-seconds err-time)))
       (kubernetes-state-update :update-last-error nil))))

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -47,8 +47,8 @@
 
 (kubernetes-ast-define-component statefulset-line (state statefulset)
   (-let* ((current-time (kubernetes-state-current-time state))
-          (pending-deletion (kubernetes-state-statefulsets-pending-deletion state))
-          (marked-statefulsets (kubernetes-state-marked-statefulsets state))
+          (pending-deletion (kubernetes-state--get state 'statefulsets-pending-deletion))
+          (marked-statefulsets (kubernetes-state--get state 'marked-statefulsets))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)
 
                    'spec (&alist 'replicas desired)
@@ -130,7 +130,7 @@
 (kubernetes-state-define-refreshers statefulsets)
 
 (defun kubernetes-statefulsets-delete-marked (state)
-  (let ((names (kubernetes-state-marked-statefulsets state)))
+  (let ((names (kubernetes-state--get state 'marked-statefulsets)))
     (dolist (name names)
       (kubernetes-state-delete-statefulset name)
       (kubernetes-kubectl-delete "statefulset" name kubernetes-props state

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -46,7 +46,7 @@
       (key-value 12 "Created" ,time))))
 
 (kubernetes-ast-define-component statefulset-line (state statefulset)
-  (-let* ((current-time (kubernetes-state-current-time state))
+  (-let* ((current-time (kubernetes-state--get state 'current-time))
           (pending-deletion (kubernetes-state--get state 'statefulsets-pending-deletion))
           (marked-statefulsets (kubernetes-state--get state 'marked-statefulsets))
           ((&alist 'metadata (&alist 'name name 'creationTimestamp created-time)

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -196,10 +196,8 @@
 
 (defmacro kubernetes-state-marking-tests (resource)
   (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
-
         (get-pending-deletion-fn
          (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
-        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -143,7 +143,7 @@
                `((message . "Foo")
                  (command . "Cmd")
                  (time . , time))
-               (kubernetes-state-last-error (kubernetes-state)))))))
+               (kubernetes-state--get (kubernetes-state) 'last-error))))))
 
 (kubernetes-state-test-accessor label-query
   (kubernetes-state-update-label-query "test"))
@@ -274,14 +274,14 @@
     (let* ((time (current-time))
            (kubernetes-state--current-state `((last-error . ((time . ,time))))))
       (kubernetes-state-clear-error-if-stale 5)
-      (should (kubernetes-state-last-error (kubernetes-state))))))
+      (should (kubernetes-state--get (kubernetes-state) 'last-error)))))
 
 (ert-deftest kubernetes-state-test--clear-error-if-stale--stale ()
   (test-helper-with-empty-state
     (let* ((time (time-subtract (current-time) (time-to-seconds 10)))
            (kubernetes-state--current-state `((last-error . ((time . ,time))))))
       (kubernetes-state-clear-error-if-stale 5)
-      (should (null (kubernetes-state-last-error (kubernetes-state)))))))
+      (should (null (kubernetes-state--get (kubernetes-state) 'last-error))))))
 
 (ert-deftest kubernetes-state-test--lookup-pod--no-such-pod ()
   (test-helper-with-empty-state

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -195,8 +195,11 @@
 ;; Test marking/unmarking/deleting actions
 
 (defmacro kubernetes-state-marking-tests (resource)
-  (let ((get-marks-fn (intern (format "kubernetes-state-marked-%ss" resource)))
-        (get-pending-deletion-fn (intern (format "kubernetes-state-%ss-pending-deletion" resource)))
+  (let ((get-marks-fn (-rpartial #'kubernetes-state--get (intern (format "marked-%ss" resource))))
+
+        (get-pending-deletion-fn
+         (-rpartial #'kubernetes-state--get (intern (format "%ss-pending-deletion" resource))))
+        
         (update-fn (intern (format "kubernetes-state-update-%ss" resource)))
         (mark-fn (intern (format "kubernetes-state-mark-%s" resource)))
         (unmark-fn (intern (format "kubernetes-state-unmark-%s" resource)))


### PR DESCRIPTION
Relates to #69.

This PR removes the resource-specific getters for "marked" default k8s resources, e.g. pods and deployments, in favor of the generic counterpart introduced in #200.

## Side Note

As we move forward with resource-handling genericization, it might benefit us to likewise look into a more generic handling of marked status for resources, rather than introduce one new field in the state alist for each resource. We can have that discussion elsewhere.