### PR TITLE
Exec: Mark vterm suffix as inaccessible if vterm is not installed

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,7 +6,12 @@ The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]
 versioning]].
 
 * Upcoming
-   
+  
+** Changed
+
+   - Explicitly disable the =Exec into container using vterm= suffix of the
+     =kubernetes-exec= transient if =vterm= is not installed ([[https://github.com/kubernetes-el/kubernetes-el/pull/209][#209]])
+     
 * 0.16.0
   
 ** Changed

--- a/kubernetes-popups.el
+++ b/kubernetes-popups.el
@@ -48,10 +48,11 @@
    ("-i" "Pass stdin to container" "--stdin")
    ("-t" "Stdin is a TTY" "--tty")]
   ["Options"
-   ("=c" "Container to exec within" "--container=" kubernetes-utils-read-container-name)]
+   ("=c" "Container to exec within" "--container=" :reader kubernetes-utils-read-container-name)]
   [["Actions"
     ("e" "Exec" kubernetes-exec-into)
-    ("v" "Exec into container using vterm" kubernetes-exec-using-vterm)]])
+    ("v" "Exec into container using vterm" kubernetes-exec-using-vterm
+     :inapt-if-not (lambda () (require 'vterm nil 'noerror)))]])
 
 (transient-define-prefix kubernetes-file ()
   "Work with files in Kubernetes resources."


### PR DESCRIPTION
This PR uses the `inapt-if-not` slot in `transient-suffix` to grey out the
`k8s-exec-using-vterm` suffix if `vterm` is not installed, flat-out preventing
the user from invoking that suffix.

<img width="549" alt="image" src="https://user-images.githubusercontent.com/1932579/131253760-1885e583-8321-4fb2-be4e-71f7dd77de20.png">
