### PR TITLE
Jobs: Properly lookup pod for job

### DIFF
--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -94,11 +94,11 @@
                                    line)))))))
 
 (defun kubernetes-jobs--lookup-pod-for-job (job state)
-  (-let* (((&alist 'metadata (&alist 'labels (&alist 'job-name job-name))) job)
+  (-let* ((job-name (kubernetes-state-resource-name job))
           ((&alist 'items items) (kubernetes-state--get state 'pods)))
     (seq-find (lambda (pod)
-                (let ((pod-name (kubernetes-state-resource-name pod)))
-                  (string-prefix-p job-name pod-name)))
+                (-let (((&alist 'metadata (&alist 'labels (&alist 'job-name pod-job-name))) pod))
+                  (string= pod-job-name job-name)))
               items)))
 
 (kubernetes-ast-define-component job (state job)

--- a/test/resources/get-jobs-response.json
+++ b/test/resources/get-jobs-response.json
@@ -10,8 +10,7 @@
         },
         "creationTimestamp": "2017-04-22T22:00:02Z",
         "labels": {
-          "controller-uid": "09768995-26a7-11e7-aed8-12c05cb0b29d",
-          "job-name": "example-svc-v3-1603416598"
+          "controller-uid": "09768995-26a7-11e7-aed8-12c05cb0b29d"
         },
         "name": "example-job-1",
         "namespace": "mm",
@@ -32,7 +31,7 @@
             "creationTimestamp": null,
             "labels": {
               "controller-uid": "09768996-27a7-11e7-aed8-12c06cb0b29d",
-              "job-name": "example-svc-v3-1603416598"
+              "job-name": "example-job-1"
             }
           },
           "spec": {

--- a/test/resources/get-pods-response.json
+++ b/test/resources/get-pods-response.json
@@ -12,6 +12,7 @@
         "generateName": "example-svc-v3-1603416598-",
         "labels": {
           "name": "example-pod-v3",
+          "job-name": "example-job-1",
           "pod-template-hash": "1603416598"
         },
         "name": "example-svc-v3-1603416598-2f9lb",


### PR DESCRIPTION
Hi, I'm a new user. I noticed that jobs view was crashing and looked into it. My fix does two things:
- `job-name` was fetched from metadata/labels/job-name of the job, instead of than just metadata/name. This later crashed in `(string-prefix-p nil job-name)`. 
- We can just compare the label `job-name` of the pod, rather than checking if job-name is a prefix of pod-name.

Also, we probably want seq-filter instead of seq-find, since a job can have multiple pods?

Cheers
