### PR TITLE
Disable timers if kubernetes-{poll,redraw}-frequency are nil

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,8 +52,8 @@ example one can use the following configuration:
   :ensure t
   :commands (kubernetes-overview)
   :config
-  (setq kubernetes-poll-frequency 3600
-        kubernetes-redraw-frequency 3600))
+  (setq kubernetes-poll-frequency nil
+        kubernetes-redraw-frequency nil))
 ```
 
 ## Manual Installation

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -90,7 +90,8 @@ The function must take a single argument, which is the buffer to display."
 (defcustom kubernetes-poll-frequency 5
   "The frequency in seconds at which to poll Kubernetes for changes."
   :group 'kubernetes
-  :type 'integer)
+  :type '(choice (integer :tag "Frequency in seconds")
+                 (const :tag "Disabled" nil)))
 
 (defcustom kubernetes-redraw-frequency 5
   "The buffer redraw frequency in seconds.
@@ -99,7 +100,8 @@ This is the frequency at which Kubernetes buffers will be redrawn
 to match the current state.  This variable should be tuned to
 balance interface stuttering with update frequency."
   :group 'kubernetes
-  :type 'integer)
+  :type '(choice (integer :tag "Frequency in seconds")
+                 (const :tag "Disabled" nil)))
 
 (defcustom kubernetes-json-mode 'javascript-mode
   "The mode to use when rendering pretty-printed JSON."


### PR DESCRIPTION
I think this looks better than some arbitrary high value