### PR TITLE
Docs: Contributing: Mention changelog procedure

### DIFF
--- a/contributing.org
+++ b/contributing.org
@@ -26,13 +26,16 @@ If the issue relates to integration with =kubectl=, make sure to supply your
 
 ** Code changes
 
-For code changes, please follow the following guidelines.
+   For code changes, please follow the following guidelines.
 
-- Create a GitHub issue to track your work
-- Fork the repository on GitHub
-- Create a feature branch for your PR
-- Take the time to write good commit messages
-- Run tests and make sure they all pass before submitting your PR.
+   - Create a GitHub issue to track your work
+   - Fork the repository on GitHub
+   - Create a feature branch for your PR
+   - Take the time to write good commit messages; [[https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/][here]] are some practical tips.
+   - Run tests and make sure they all pass before submitting your PR.
+   - If your contribution is a user-facing change, please add an entry to
+     =CHANGELOG.org= in thet =Unreleased= section detailing it. See
+     [[https://keepachangelog.com/en/1.0.0/][keepachangelog.com]] for an overview of this process.
 
 * Development setup
 


### PR DESCRIPTION
We recently adopted the changelog procedure outlined at
keepachangelog.com. However, we make no mention of it in the contributor guide,
leading to unnecessary back-and-forth and explanation between maintainers and
contributors.

To avoid confusion and provide clarity moving forward, we note the procedure in
the contributor guide here.