### PR TITLE
Process tracking: Implement new, comprehensive, agnostic tracker

### DIFF
--- a/kubernetes-process.el
+++ b/kubernetes-process.el
@@ -2,6 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 'dash)
 (require 'map)
 (require 'subr-x)
 
@@ -30,7 +31,7 @@ live or not."
 This function is a no-op if there is no process.
 
 If the process is already dead, clean it up."
-  (when-let* ((proc (get-process-for-resource ledger resource)))
+  (-when-let* ((proc (get-process-for-resource ledger resource)))
     (when (process-live-p proc)
       (kubernetes-process-kill-quietly proc))
     (if (not (slot-value ledger 'poll-processes))

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -26,6 +26,7 @@ will be mocked."
              ;; Silence byte-compiler warnings
              this-fn
 
+             
              (let ((buf (generate-new-buffer " test")))
                (with-current-buffer buf
                  (unwind-protect
@@ -35,7 +36,13 @@ will be mocked."
                        (funcall on-success buf)))
 
                  (when cleanup-cb
-                   (funcall cleanup-cb))))))
+                   (funcall cleanup-cb))))
+             ;; Make and return a "dummy" process here solely to conform to the
+             ;; expected return value of kubernetes-kubectl
+             (make-process
+              :name "dummy process"
+              :command '("sleep" "0")
+              :noquery t)))
      ,@forms))
 
 (defmacro with-error-response-at (expected-args response-string &rest forms)
@@ -65,7 +72,14 @@ will be mocked."
                        (funcall on-error buf))
 
                    (when cleanup-cb
-                     (funcall cleanup-cb)))))))
+                     (funcall cleanup-cb)))))
+
+             ;; Make and return a "dummy" process here solely to conform to the
+             ;; expected return value of kubernetes-kubectl
+             (make-process
+              :name "dummy process"
+              :command '("sleep" "0")
+              :noquery t)))
      ,@forms))
 
 (defconst kubernetes-kubectl-test-props

--- a/tests/test-process.el
+++ b/tests/test-process.el
@@ -1,0 +1,107 @@
+;;; test-process.el --- Tests for process management. -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(load-file "./tests/undercover-init.el")
+
+(require 'kubernetes-process)
+
+(describe "Process ledger"
+  :var (ledger)
+  (before-each
+    (setq ledger (kubernetes--process-ledger))
+    (spy-on 'process-live-p
+            :and-call-fake
+            (lambda (proc)
+              (cond
+               ((eq proc :fake-proc-live) t)
+               ((eq proc :fake-proc-dead) nil)))))
+
+  (describe "process lookup"
+    (it "returns the process for resources"
+      (setq ledger (kubernetes--process-ledger
+                    :poll-processes '((pods . t)
+                                      (deployments . nil))))
+      (expect (get-process-for-resource ledger 'pods) :to-equal t)
+      (expect (get-process-for-resource ledger 'deployments) :to-equal nil))
+
+    (it "returns nil for resources with no process"
+      (expect (get-process-for-resource ledger 'pods) :to-equal nil)))
+
+  (describe "process setting"
+    (describe "with empty processes list"
+      (before-each
+        (spy-on 'kubernetes-process-kill-quietly))
+      (it "assigns successfully"
+        (setq ledger (kubernetes--process-ledger))
+        (set-process-for-resource ledger 'pods :fake-proc-live))
+
+      (it "assigns, unassigns, then re-assigns successfully"
+        (setq ledger (kubernetes--process-ledger))
+        (set-process-for-resource ledger 'pods :fake-proc-live)
+        (release-process-for-resource ledger 'pods)
+        (set-process-for-resource ledger 'pods :fake-proc-dead)
+        (expect (get-process-for-resource ledger 'pods) :to-equal :fake-proc-dead)))
+
+    (describe "with existing processes"
+      :var (ledger)
+      (before-each
+        (spy-on 'release-process-for-resource)
+        (setq ledger (kubernetes--process-ledger
+                      :poll-processes '((pods . nil)
+                                        (services . :fake-proc-dead)
+                                        (deployments . :fake-proc-live)))))
+
+      (it "assigns successfully if no process exists"
+        (expect (set-process-for-resource ledger 'pods :fake-proc-live) :not :to-throw 'error)
+        (expect (get-process-for-resource ledger 'pods) :to-equal :fake-proc-live))
+
+      (it "assigns successfully if no live process exists"
+        (expect (set-process-for-resource ledger 'services :fake-proc-live) :not :to-throw 'error)
+        (expect (get-process-for-resource ledger 'services) :to-equal :fake-proc-live))
+
+      (it "assigns successfully if live process already exists, with force"
+        (expect (set-process-for-resource ledger 'services :foo t) :not :to-throw 'error)
+        (expect 'release-process-for-resource :to-have-been-called-with ledger 'services)
+        (expect (get-process-for-resource ledger 'services) :to-equal :foo))
+
+      (it "errors if a live process already exists"
+        (expect (set-process-for-resource ledger 'deployments :fake-proc-live) :to-throw 'error))))
+
+  (describe "process releasing"
+    (before-each
+      (setq ledger (kubernetes--process-ledger
+                    :poll-processes '((pods . :fake-proc-dead)
+                                      (deployments . :fake-proc-live)
+                                      (services . nil))))
+      (spy-on 'kubernetes-process-kill-quietly))
+
+    (it "releases existing live processes"
+      (release-process-for-resource ledger 'deployments)
+      (expect 'kubernetes-process-kill-quietly :to-have-been-called-with
+              :fake-proc-live)
+      (expect (get-process-for-resource ledger 'deployments) :to-equal nil))
+
+    (it "cleans up if existing process is already dead"
+      (release-process-for-resource ledger 'pods)
+      (expect 'kubernetes-process-kill-quietly :not :to-have-been-called)
+      (expect (get-process-for-resource ledger 'pods) :to-equal nil))
+
+    (it "no-ops if no existing process"
+      (release-process-for-resource ledger 'services)
+      (expect 'kubernetes-process-kill-quietly :not :to-have-been-called)))
+
+  (describe "liveness checking"
+    (it "returns the liveness of the process"
+
+      (setq ledger (kubernetes--process-ledger
+                    :poll-processes '((pods . :fake-proc-live)
+                                      (secrets . :fake-proc-dead)
+                                      (deployments . nil))))
+
+      (expect (poll-process-live-p ledger 'pods) :to-be-truthy)
+      (expect (poll-process-live-p ledger 'secrets) :not :to-be-truthy)
+      (expect (poll-process-live-p ledger 'deployments) :not :to-be-truthy)
+      (expect (poll-process-live-p ledger 'services) :not :to-be-truthy))))
+
+;;; test-process.el ends here


### PR DESCRIPTION
Relates to #234.

As the first step towards a resource-agnostic process tracking strategy, this PR
implements `kubernetes--process-ledger`, an EIEIO-based ledger class to keep
track of processes corresponding to given resources. This PR also reimplements
the existing resource-specific process-related constructs,
e.g. `kubernetes-process-pods-process-live-p`, to be with respect to a global
instance of this new ledger class.