### PR TITLE
Use global process ledger everywhere directly

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,12 +8,23 @@ versioning]].
 * Upcoming
 
 ** Changed
+   
    - New overview for persistent volume claims. ([[https://github.com/kubernetes-el/kubernetes-el/pull/223][#223]])
    - Added a new interactive function, =kubernetes-contexts-rename=, for
      renaming contexts. ([[https://github.com/kubernetes-el/kubernetes-el/pull/231][#231]])
    - Added a new transient prefix, =kubernetes-context=, for acting on kubectl
      contexts, e.g. switching, renaming, etc. ([[https://github.com/kubernetes-el/kubernetes-el/pull/231][#231]])
 
+** Refinements
+
+   - We've taken a big step towards [[https://github.com/kubernetes-el/kubernetes-el/issues/69][support for custom resources]], overhauling
+     the process-tracking module -- how =kubernetes-el= keeps track of the
+     various =kubectl= processes that it spins up -- to be resource agnostic
+     ([[https://github.com/kubernetes-el/kubernetes-el/issues/234][#234]]). This removes another section of the codebase that historically has
+     had to be updated for every new resource that =kubernetes-el= wants to
+     "support," allowing it to accommodate any and all resources. See: [[https://github.com/kubernetes-el/kubernetes-el/pull/237][#237]];
+     [[https://github.com/kubernetes-el/kubernetes-el/pull/238][#238]].
+     
 * 0.17.0
   
 ** Changed

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -8,6 +8,7 @@
 (require 'subr-x)
 
 (require 'kubernetes-vars)
+(require 'kubernetes-process)
 
 
 ;;; Main state
@@ -464,8 +465,8 @@ arguments."
          (canned (or canned (-partial #'kubernetes-kubectl-get s-attr))))
     `(progn
        (defun ,(intern (format "kubernetes-%s-refresh" s-attr)) (&optional interactive)
-         (unless (,(intern (format "kubernetes-process-poll-%s-process-live-p" s-attr)))
-           (,(intern (format "kubernetes-process-set-poll-%s-process" s-attr))
+         (unless (poll-process-live-p kubernetes--global-process-ledger (quote ,attr))
+           (set-process-for-resource kubernetes--global-process-ledger (quote ,attr)
             (funcall
              ,canned
              kubernetes-props
@@ -474,8 +475,8 @@ arguments."
                (,(intern (format "kubernetes-state-update-%s" s-attr)) response)
                (when interactive
                  (message (concat "Updated " ,s-attr "."))))
-             (function
-              ,(intern (format "kubernetes-process-release-poll-%s-process" s-attr)))))))
+             (-partial 'release-process-for-resource kubernetes--global-process-ledger (quote ,attr))
+             ))))
        (defun ,(intern (format "kubernetes-%s-refresh-now" s-attr)) (&optional interactive)
          (interactive "p")
          (kubernetes-state--refresh-now (quote ,attr) interactive ,raw)))))


### PR DESCRIPTION
Closes #234.

This PR caps off the groundwork laid by #237 and #238, rendering process
tracking fully resource-agnostic.