### PR TITLE
Implement initialization + tracking of kubectl proxy process

### DIFF
--- a/kubernetes-process.el
+++ b/kubernetes-process.el
@@ -13,14 +13,14 @@
   "Send request to URL using BODY, returning error or the response.
 
 This function injects :sync t into BODY."
-  (if-let* ((updated-plist
-             (plist-put (plist-put body :sync t)
-                        ;; Suppress the default request.el error handler; we
-                        ;; check the error later
-                        :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
-                                              nil))))
-            (resp (apply #'request url updated-plist))
-            (err (request-response-error-thrown resp)))
+  (-if-let* ((updated-plist
+              (plist-put (plist-put body :sync t)
+                         ;; Suppress the default request.el error handler; we
+                         ;; check the error later
+                         :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                                               nil))))
+             (resp (apply #'request url updated-plist))
+             (err (request-response-error-thrown resp)))
       (signal 'error (list (cdr err)))
     resp))
 

--- a/kubernetes-process.el
+++ b/kubernetes-process.el
@@ -4,7 +4,66 @@
 
 (require 'dash)
 (require 'map)
+(require 'request)
 (require 'subr-x)
+
+(require 'kubernetes-vars)
+
+(defun kubernetes--request-option (url &rest body)
+  "Send request to URL using BODY, returning error or the response.
+
+This function injects :sync t into BODY."
+  (if-let* ((updated-plist
+             (plist-put (plist-put body :sync t)
+                        ;; Suppress the default request.el error handler; we
+                        ;; check the error later
+                        :error (cl-function (lambda (&rest args &key error-thrown &allow-other-keys)
+                                              nil))))
+            (resp (apply #'request url updated-plist))
+            (err (request-response-error-thrown resp)))
+      (signal 'error (list (cdr err)))
+    resp))
+
+
+;; TODO: Make a ported-process-record-with-timeout class that terminates the
+;; process after certain TTL
+(defclass kubernetes--ported-process-record ()
+  ((process
+    :initarg :process
+    :initform nil
+    :documentation "Process object.")
+   (port
+    :initarg :port
+    :initform nil
+    :documentation "Port corresponding to the process."))
+  "Record for a process with a corresponding network port.")
+
+(cl-defmethod wait-on-endpoint ((record kubernetes--ported-process-record)
+                                endpoint
+                                &optional retry-count retry-wait)
+  "Wait for RECORD process to respond without error at PORT and ENDPOINT.
+
+Retries RETRY-COUNT times, waiting RETRY-WAIT seconds in between
+  each attempt.  Returns the response code.  If ENDPOINT fails to
+  respond after retries, signals error."
+  (let ((_retry-count (or retry-count 5))
+        (_retry-wait (or retry-wait 2))
+        (retval))
+    (while (and (not retval) (> _retry-count 0))
+      (condition-case nil
+          (setq retval
+                (kubernetes--request-option (format "http://localhost:%s/%s"
+                                                    (oref record port)
+                                                    endpoint)))
+        (error (progn
+                 (setq _retry-count (- _retry-count 1))
+                 (sleep-for _retry-wait)))))
+    (cond
+     ((not retval) (error "Process with port %s was not ready within accepted timeframe"
+                          (oref record port)))
+     (t (request-response-status-code retval)))
+    )
+  )
 
 (defclass kubernetes--process-ledger ()
   ((poll-processes
@@ -12,16 +71,56 @@
     :initform '()
     :documentation "Mapping between resources and their polling
   processes. Keys are expected to be in plural form, i.e. 'pods'
-  instead of 'pod' and so on."))
+  instead of 'pod' and so on.")
+   (proxy
+    :initarg :proxy
+    :initform nil
+    :documentation "Proxy process. There should only be one of these at a time."))
   "Track Kubernetes processes.")
+
+(cl-defmethod proxy-ready-p ((ledger kubernetes--process-ledger))
+  "Wait for proxy process of LEDGER to be ready for requests.
+
+Returns nil if the proxy has started, but either readyz or livez
+  endpoints return non-200."
+  (let ((proxy-record (oref ledger proxy)))
+    (and (= 200 (wait-on-endpoint proxy-record "readyz"))
+         (= 200 (wait-on-endpoint proxy-record "livez")))))
+
+(cl-defmethod get-proxy-process ((ledger kubernetes--process-ledger))
+  "Get a proxy process from LEDGER.
+
+If there is already a process recorded in the ledger, return that process.
+  Otherwise, make a new one, record it in the ledger, and return it."
+  (if-let ((proxy-proc-record (oref ledger proxy)))
+      (oref proxy-proc-record process)
+    (let* ((port kubernetes-default-proxy-port)
+           (proxy-output-buffer (generate-new-buffer
+                                 (format "*kubectl proxy<%s>*" port)))
+           (proxy-proc (make-process
+                          :name (format "kubectl proxy<%s>" port)
+                          :command `("kubectl"
+                                     "proxy"
+                                     "--port"
+                                     ,(format "%s" port))
+                          :buffer proxy-output-buffer
+                          :stderr nil       ; send stderr to stdout
+                          :noquery t)))
+      (oset ledger proxy (kubernetes--ported-process-record
+                          :process proxy-proc
+                          :port port))
+      (if (proxy-ready-p ledger)
+          proxy-proc
+        (kill-process proxy-proc)
+        (oset ledger proxy nil)
+        (error "Failed to start kubectl proxy")))))
 
 (cl-defmethod get-process-for-resource ((ledger kubernetes--process-ledger) resource)
   "Get polling process for RESOURCE in LEDGER."
   (map-elt (slot-value ledger 'poll-processes) resource))
 
 (cl-defmethod poll-process-live-p ((ledger kubernetes--process-ledger) resource)
-  "Determine if the polling process for RESOURCE in LEDGER is
-live or not."
+  "Determine live-ness of RESOURCE's polling process in LEDGER."
   (process-live-p (get-process-for-resource ledger resource)))
 
 (cl-defmethod release-all ((ledger kubernetes--process-ledger))

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -12,11 +12,18 @@
   :group 'kubernetes
   :type 'integer)
 
+(define-widget 'kubernetes--positive-int 'lazy
+  "A positive integer."
+  :type '(restricted-sexp
+          :tag "Positive integer"
+          :match-alternatives
+          ((lambda (val)
+             (and (integerp val) (> val 0))))))
+
 (defcustom kubernetes-default-proxy-port 8001
   "Default port to run kubectl proxies on."
   :group 'kubernetes
-  :type '(choice (integer :tag "Explicit port")
-                 (const :tag "Random" 0))
+  :type 'kubernetes--positive-int
   :link '(url-link "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#proxy"))
 
 (defcustom kubernetes-kubectl-executable "kubectl"

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -12,6 +12,13 @@
   :group 'kubernetes
   :type 'integer)
 
+(defcustom kubernetes-default-proxy-port 8001
+  "Default port to run kubectl proxies on."
+  :group 'kubernetes
+  :type '(choice (integer :tag "Explicit port")
+                 (const :tag "Random" 0))
+  :link '(url-link "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#proxy"))
+
 (defcustom kubernetes-kubectl-executable "kubectl"
   "The kubectl command used for Kubernetes commands."
   :group 'kubernetes

--- a/kubernetes.el
+++ b/kubernetes.el
@@ -39,11 +39,11 @@
 (require 'kubernetes-el-tramp)
 
 (defmacro kubernetes--with-proxy (&rest body)
-  "Run BODY with a kubectl proxy active in the background at PORT.
+  "Run BODY with a kubectl proxy active in the background.
 
-Terminates the proxy on completion of BODY."
+The proxy process is accessible at `it'."
   (declare (indent 2))
-  `(let* ((proxy-proc (get-proxy-process kubernetes--global-process-ledger)))
+  `(let* ((it (get-proxy-process kubernetes--global-process-ledger)))
      ,@body))
 
 (provide 'kubernetes)

--- a/kubernetes.el
+++ b/kubernetes.el
@@ -9,7 +9,7 @@
 
 ;; Version: 0.17.0
 ;; Homepage: https://github.com/kubernetes-el/kubernetes-el
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (transient "0.3.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (request "0.3.2") (transient "0.3.0"))
 ;; Keywords: kubernetes
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,14 @@
 (require 'kubernetes-logs)
 (require 'kubernetes-overview)
 (require 'kubernetes-el-tramp)
+
+(defmacro kubernetes--with-proxy (&rest body)
+  "Run BODY with a kubectl proxy active in the background at PORT.
+
+Terminates the proxy on completion of BODY."
+  (declare (indent 2))
+  `(let* ((proxy-proc (get-proxy-process kubernetes--global-process-ledger)))
+     ,@body))
 
 (provide 'kubernetes)
 

--- a/tests/test-kubernetes.el
+++ b/tests/test-kubernetes.el
@@ -1,0 +1,17 @@
+;;; test-kubernetes.el --- Tests for general constructs. -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(load-file "./tests/undercover-init.el")
+
+(require 'kubernetes)
+
+(describe "kubernetes--with-proxy"
+  (before-each
+    (spy-on 'get-proxy-process :and-return-value :sentinel-proxy-process))
+
+  (it "can access the proxy process via `it'"
+    (kubernetes--with-proxy
+        (expect it :to-equal :sentinel-proxy-process))))
+
+;;; test-kubernetes.el ends here

--- a/tests/test-process.el
+++ b/tests/test-process.el
@@ -140,4 +140,23 @@
         (setq ledger (kubernetes--process-ledger))
         (expect (get-proxy-process ledger) :to-equal :new-proxy-proc)))))
 
+(describe "Ported process record"
+  (describe "process waiting"
+    (describe "retrying"
+      (before-each
+        (spy-on 'sleep-for))
+      (it "retries by default"
+        (spy-on 'kubernetes--request-option :and-throw-error 'error)
+        (expect (wait-on-endpoint (kubernetes--ported-process-record) "foo")
+                :to-throw 'error)
+        (expect 'sleep-for :to-have-been-called-times 5)
+        (expect 'kubernetes--request-option :to-have-been-called-times 5))
+      (it "retries by specified count and wait time"
+        (spy-on 'kubernetes--request-option :and-throw-error 'error)
+        (expect (wait-on-endpoint (kubernetes--ported-process-record) "foo" 10 3)
+                :to-throw 'error)
+        (expect 'sleep-for :to-have-been-called-times 10)
+        (expect 'sleep-for :to-have-been-called-with 3)
+        (expect 'kubernetes--request-option :to-have-been-called-times 10)))))
+
 ;;; test-process.el ends here

--- a/tests/test-process.el
+++ b/tests/test-process.el
@@ -5,6 +5,26 @@
 (load-file "./tests/undercover-init.el")
 
 (require 'kubernetes-process)
+(require 'request)
+
+(describe "kubernetes--request-option"
+  (describe "when request throws an error"
+    (before-each
+      (spy-on 'request
+              :and-call-fake (lambda (&rest _)
+                               (make-request-response
+                                :status-code 404
+                                :error-thrown (error . ("bar"))))))
+    (it "throws an error"
+      (expect (kubernetes--request-option "foo") :to-throw 'error)))
+  (describe "when request returns successfully"
+    (before-each
+      (spy-on 'request
+              :and-return-value (make-request-response
+                                 :status-code 200
+                                 :error-thrown nil)))
+    (it "returns the response"
+      (expect (kubernetes--request-option "foo") :to-be-truthy))))
 
 (describe "Process ledger"
   :var (ledger)

--- a/tests/test-process.el
+++ b/tests/test-process.el
@@ -120,6 +120,24 @@
       (expect (poll-process-live-p ledger 'pods) :to-be-truthy)
       (expect (poll-process-live-p ledger 'secrets) :not :to-be-truthy)
       (expect (poll-process-live-p ledger 'deployments) :not :to-be-truthy)
-      (expect (poll-process-live-p ledger 'services) :not :to-be-truthy))))
+      (expect (poll-process-live-p ledger 'services) :not :to-be-truthy)))
+
+  (describe "proxy process"
+    (before-each
+      (spy-on 'make-process :and-return-value :new-proxy-proc))
+
+    (describe "when there's an existing process"
+      (before-each
+        (setq ledger (kubernetes--process-ledger
+                      :proxy (kubernetes--ported-process-record
+                              :process :existing-proxy-proc))))
+      (it "returns that process"
+        (expect (get-proxy-process ledger) :to-equal :existing-proxy-proc)))
+    (describe "when no existing process"
+      (before-each
+        (spy-on 'proxy-ready-p :and-return-value t))
+      (it "creates new process"
+        (setq ledger (kubernetes--process-ledger))
+        (expect (get-proxy-process ledger) :to-equal :new-proxy-proc)))))
 
 ;;; test-process.el ends here


### PR DESCRIPTION
Contributes to #235.

This PR introduces the `kubernetes--with-proxy` macro, which allows for
executing a block of code with the guarantee of a `kubectl proxy` kicking off,
or having already kicked off, in the background. This paves the way for us to
make HTTP requests to the Kubernetes API via the proxy.

One downside here is that the proxy process lives indefinitely once it's kicked
off. Ideally, this process would have a TTL where it shuts down after going
unused for a specified amount of time. This can be future work. Due to this,
however, we should only merge this PR in once #232 is addressed.