### PR TITLE
CI: Bump Python version from 3.6 to 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python (for Cask)
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.9'
           architecture: 'x64'
 
       - name: Setup Cask


### PR DESCRIPTION
Given that Python 3.6 has reached EoL.