### PR TITLE
Introduce primitives for tracking processes w/ ports + addresses

### DIFF
--- a/kubernetes.el
+++ b/kubernetes.el
@@ -9,7 +9,7 @@
 
 ;; Version: 0.17.0
 ;; Homepage: https://github.com/kubernetes-el/kubernetes-el
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (transient "0.3.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (request "0.3.2") (transient "0.3.0"))
 ;; Keywords: kubernetes
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Contributes to #247.

This PR introduces `kubernetes--ported-process-record`, a class that facilitates
interaction with processes that correspond to local ports. It provides methods
such as:

- Interpolating the base URL, e.g. `http://localhost:<port>`;

- Waiting for response code from a specific endpoint thereon,
e.g. `http://localhost:<port>/livez` (for the Kubernetes server);

This class will be necessary for systematic tracking of proxy servers created by
`kubectl` as outlined in #247 and implemented in #252.