### PR TITLE
Introduce rudimentary leveled-logging constructs

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -4,6 +4,7 @@
 
 (require 'kubernetes-ast)
 (require 'kubernetes-contexts)
+(require 'kubernetes-core)
 (require 'kubernetes-modes)
 (require 'kubernetes-popups)
 (require 'kubernetes-props)
@@ -177,7 +178,7 @@ buffers."
       (when (or no-confirm (y-or-n-p (format "Kill %s Kubernetes buffer(s)? " num-buffers)))
         (dolist (buffer buffers)
           (kill-buffer buffer))
-        (message "Killed %s Kubernetes buffers." num-buffers)))))
+        (kubernetes--info "Killed %s Kubernetes buffers." num-buffers)))))
 
 (defun kubernetes-kill-buffers-and-processes (&optional no-confirm)
   "Kill all kubernetes-el buffers and all processes.

--- a/kubernetes-core.el
+++ b/kubernetes-core.el
@@ -1,0 +1,34 @@
+;; kubernetes-core.el --- core functionality -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'kubernetes-vars)
+
+(defun kubernetes--message (format &rest args)
+  "Call `message' with FORMAT and ARGS.
+
+We `inhibit-message' the message when the cursor is in the
+minibuffer and when Emacs version is before Emacs 27 due to the
+fact that we often use `kubernetes--info', `kubernetes--warn' and
+`kubernetes--error' in async context and the call to these
+function is removing the minibuffer prompt.  The issue with async
+messages is already fixed in Emacs 27."
+  (when kubernetes-show-message
+    (let ((inhibit-message (and (minibufferp)
+                                (version< emacs-version "27.0"))))
+      (apply #'message format args))))
+
+(defun kubernetes--info (format &rest args)
+  "Display kubernetes info message with FORMAT with ARGS."
+  (kubernetes--message "%s :: %s" (propertize "k8s" 'face 'success) (apply #'format format args)))
+
+(defun kubernetes--warn (format &rest args)
+  "Display kubernetes warn message with FORMAT with ARGS."
+  (kubernetes--message "%s :: %s" (propertize "k8s" 'face 'warning) (apply #'format format args)))
+
+(defun kubernetes--error (format &rest args)
+  "Display kubernetes error message with FORMAT with ARGS."
+  (kubernetes--message "%s :: %s" (propertize "k8s" 'face 'error) (apply #'format format args)))
+
+(provide 'kubernetes-core)
+;;; kubernetes-core.el ends here

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -7,6 +7,11 @@
   :group 'tools
   :prefix "kubernetes-")
 
+(defcustom kubernetes-show-message t
+  "If non-nil, show log messages from `kubernetes-el'."
+  :group 'kubernetes
+  :type 'boolean)
+
 (defcustom kubernetes-kubectl-timeout-seconds 25
   "How long to wait for kubectl before giving up."
   :group 'kubernetes


### PR DESCRIPTION
This PR introduces rudimentary mechanisms for leveled logging, e.g. `INFO`,
`WARNING`, and `ERROR`, as well as a custom variable with which users can
disable such logs. It's copied basically wholesale from [lsp-mode's
implementation][1].

[1]: https://github.com/emacs-lsp/lsp-mode/blob/master/lsp-mode.el