### PR TITLE
CI: Notify when PR drops test coverage by certain amount

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+        informational: true


### PR DESCRIPTION
This commit configures Codecov to issue an informational, i.e. non-blocking,
nudge on PRs and commits that contribute to a decrease in test coverage above a
certain quantity. See [Codecov documentation][1] for details.

[1]: https://docs.codecov.com/docs/commit-status