### PR TITLE
fix: Persist namespace change to `kubectl` configuration (#264)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install : $(TAR)
 
 test : $(SRCS)
 	${CASK} clean-elc
-	${CASK} exec ert-runner
+	${CASK} exec ert-runner --reporter ert+duration
 	${CASK} exec buttercup -L . tests/
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,13 @@ versioning][semver].
     [#237](https://github.com/kubernetes-el/kubernetes-el/pull/237);
     [#238](https://github.com/kubernetes-el/kubernetes-el/pull/238).
 
+### Fixed
+
+-   Kubernetes tramp was not respecting set namespace as there are
+    limitations to what we can pass to `tramp-login-args`
+    ([#264](https://github.com/kubernetes-el/kubernetes-el/issues/264)).
+    The fix adds one more step to update the `kubectl` configuration.
+
 ## 0.17.0
 
 ### Changed

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -433,6 +433,19 @@ STATE is the current application state."
   ;; State for the context and view should be preserved.
   (kubernetes-state-update-config (kubernetes-state--get state 'config))
   (kubernetes-state-update-current-namespace ns)
+  (kubernetes-kubectl-config-set-current-namespace kubernetes-props
+                                                   (kubernetes-state)
+                                                   (lambda (_)
+                                                     (message "Updated current context `%s' namespace to `%s.'"
+                                                              (alist-get 'name (kubernetes-state-current-context state))
+                                                              (kubernetes-state--get state 'current-namespace)))
+                                                   (lambda (buf)
+                                                     (let ((s (with-current-buffer buf (buffer-string))))
+                                                       (message "Unable to set namespace `%s' for current context `%s'."
+                                                                (kubernetes-state--get state 'current-namespace)
+                                                                (alist-get 'name (kubernetes-state-current-context state))
+                                                       (message s)))))
+
   (kubernetes-state-update-overview-sections (kubernetes-state-overview-sections state))
 
   (kubernetes-state-trigger-redraw))

--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -279,6 +279,26 @@ ERROR-CB is called if an error occurred."
                         cb
                         error-cb)))
 
+(defun kubernetes-kubectl-config-set-current-namespace (props state cb &optional error-cb)
+  "Set the kubectl namespace and execute CB with kubectl output.
+
+PROPS is an alist of functions to inject.  It should normally be passed
+`kubernetes-props'.
+
+STATE is the application state.
+
+ERROR-CB is called if an error occurred."
+  ;; The kubectl command to be executed is the following:
+  ;; kubectl config set-context --current --namespace=<ns>
+  ;; But we are not passing value for option --namespace because this
+  ;; is set from the `state' by `kubernetes-kubectl' function. The new
+  ;; namespace is set in the state by `kubernetes-set-namespace'.
+  (kubernetes-kubectl props
+                      state
+                      (list "config" "set-context" "--current")
+                      cb
+                      error-cb))
+
 (provide 'kubernetes-kubectl)
 
 ;;; kubernetes-kubectl.el ends here

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -351,4 +351,30 @@ will be mocked."
                                          (setq on-error-called t))))
     (should on-error-called)))
 
+
+;; Set kubectl namespace for the current context
+
+(ert-deftest kubernetes-kubectl-test--set-namespace-for-current-context-succeeds ()
+  (let ((success-response "Updated current context ‘context0’ namespace to ‘ns0.’"))
+    (with-successful-response-at
+     (list "config" "set-context" "--current") success-response
+     (kubernetes-kubectl-config-set-current-namespace kubernetes-kubectl-test-props
+                                                      nil
+                                                      (lambda (buf)
+                                                        (let ((s (with-current-buffer buf (buffer-string))))
+                                                          (should (equal success-response s))))))))
+
+(ert-deftest kubernetes-kubectl-test--set-namespace-for-current-context-fails ()
+  (let ((on-error-called)
+        (error-response "Unable to set namespace `ns0' for current context `context0'."))
+    (with-error-response-at
+     (list "config" "set-context" "--current") error-response
+     (kubernetes-kubectl-config-set-current-namespace kubernetes-kubectl-test-props
+                                                      nil
+                                                      (lambda (_)
+                                                        (error "Unexpected success response"))
+                                                      (lambda (_)
+                                                        (setq on-error-called t))))
+    (should on-error-called)))
+
 ;;; kubernetes-kubectl-test.el ends here


### PR DESCRIPTION
Kubernetes tramp was not respecting set namespace as there are
limitations to what we can pass to `tramp-login-args`. The fix adds
one more step to update the `kubectl` configuration.