### PR TITLE
Fix loading issue

### DIFF
--- a/kubernetes-core.el
+++ b/kubernetes-core.el
@@ -7,6 +7,8 @@
 
 (require 'kubernetes-ast)
 (require 'kubernetes-vars)
+(eval-when-compile
+  (require 'kubernetes-utils))
 
 
 (defvar kubernetes-state--current-state nil)


### PR DESCRIPTION
Yesterday I installed the latest version of the layer (for Spacemacs). However, initially, when I opened the kubernetes-overview there was an issue with rendering of the contents.

The error was something like:
invalid function: kubernetes-utils--save-window-state

Apparently the macro has not yet been not loaded at the moment that kubernetes-core.el gets compiled. This PR fixes that. 