### PR TITLE
add convenience function for copying (incl. decoding) of secrets

### DIFF
--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -203,6 +203,16 @@ window state."
     (setq dir (file-name-directory (directory-file-name dir))))
   dir)
 
+;; Useful for decoding (and copying) of kubernetes secrets
+(defun kubernetes-base64-decode-symbol-at-point (arg)
+  "Decode symbol at point (useful for displaying the contents of k8s secrets).
+
+With universal arg the value will also be copied (added to the kill-ring).
+"
+  (interactive "P")
+  (let ((result (print (base64-decode-string (thing-at-point 'symbol)))))
+    (when arg (kill-new result))))
+
 (provide 'kubernetes-utils)
 
 ;;; kubernetes-utils.el ends here


### PR DESCRIPTION
Just a simple convenience function for decoding and printing kubernetes secrets. Just put your cursor on the base64 encoded secret and run the function. Invoking the function with a universal argument also adds the decoded secret to the kill-ring.

I guess it would also be nice to create a keybinding (or two separate keybindings for both the print-only and copy options) and possibly show the keybinding(s) in the popup/transient.