### PR TITLE
Move `save-window-state` fn from `k8s-util` to `k8s-core`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,8 @@ versioning][semver].
   limitations to what we can pass to `tramp-login-args`
   ([#264](https://github.com/kubernetes-el/kubernetes-el/issues/264)).
   The fix adds one more step to update the `kubectl` configuration.
+- Fixed an implicit dependency cycle between `kubernetes-core.el` and
+  `kubernetes-utils.el`.
 
 ## 0.17.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,7 +63,7 @@ versioning][semver].
   ([#264](https://github.com/kubernetes-el/kubernetes-el/issues/264)).
   The fix adds one more step to update the `kubectl` configuration.
 - Fixed an implicit dependency cycle between `kubernetes-core.el` and
-  `kubernetes-utils.el`.
+  `kubernetes-utils.el`. ([#278])
 
 ## 0.17.0
 
@@ -99,3 +99,5 @@ versioning][semver].
   [#193](https://github.com/kubernetes-el/kubernetes-el/pull/193),
   [#198](https://github.com/kubernetes-el/kubernetes-el/pull/198),
   etc.)
+
+[#278]: https://github.com/kubernetes-el/kubernetes-el/pull/278

--- a/kubernetes-core.el
+++ b/kubernetes-core.el
@@ -37,13 +37,30 @@
         ;; Suppress redrawing if the overview is not selected. This prevents
         ;; point from jumping around when a magit popup is open.
         (when (member (selected-window) (get-buffer-window-list buf))
-          (kubernetes-utils--save-window-state
+          (kubernetes--save-window-state
            (let ((inhibit-read-only t))
              (erase-buffer)
              (kubernetes-ast-eval (kubernetes--overview-render (kubernetes-state)))))
 
           ;; Force the section at point to highlight.
           (magit-section-update-highlight))))))
+
+
+(defmacro kubernetes--save-window-state (&rest body)
+  "Restore window state after executing BODY.
+
+This is useful if the buffer is erased and repopulated in BODY,
+in which case `save-excursion' is insufficient to restore the
+window state."
+  `(let ((pos (point))
+         (col (current-column))
+         (window-start-line (window-start))
+         (inhibit-redisplay t))
+     (save-excursion
+       ,@body)
+     (goto-char pos)
+     (move-to-column col)
+     (set-window-start (selected-window) window-start-line)))
 
 (defun kubernetes--message (format &rest args)
   "Call `message' with FORMAT and ARGS.

--- a/kubernetes-labels.el
+++ b/kubernetes-labels.el
@@ -47,7 +47,7 @@
       ;; Only redraw the buffer if it is in the selected window.
       (when (equal (get-buffer-window buf)
                    (selected-window))
-        (kubernetes-utils--save-window-state
+        (kubernetes--save-window-state
          (let ((inhibit-read-only t))
            (erase-buffer)
            (kubernetes-ast-eval `(labelled-pods-list ,(kubernetes-state)))))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -182,22 +182,6 @@ buffer is killed."
 (defun kubernetes-utils-overview-buffer-selected-p ()
   (equal (current-buffer) (get-buffer kubernetes-overview-buffer-name)))
 
-(defmacro kubernetes-utils--save-window-state (&rest body)
-  "Restore window state after executing BODY.
-
-This is useful if the buffer is erased and repopulated in BODY,
-in which case `save-excursion' is insufficient to restore the
-window state."
-  `(let ((pos (point))
-         (col (current-column))
-         (window-start-line (window-start))
-         (inhibit-redisplay t))
-     (save-excursion
-       ,@body)
-     (goto-char pos)
-     (move-to-column col)
-     (set-window-start (selected-window) window-start-line)))
-
 (defun kubernetes-utils-up-to-existing-dir (dir)
   (while (not (file-directory-p dir))
     (setq dir (file-name-directory (directory-file-name dir))))


### PR DESCRIPTION
Closes #265.

The function `kubernetes-utils--save-window-state` has created an implicit
dependency cycle between `kubernetes-core.el` and `kubernetes-utils.el`. This is
not outright caused by the former `require`-ing the latter, which is itself a
mistake; adding the `require` exposes the import cycle.

This symptom is an excellent example of the overly ambiguous and broad scope of
the `-utils` package. Since the `--save-window-state` function is arguably
"core" functionality, we simply move it to the `-core` package and rename all
references accordingly.