### PR TITLE
Add Markdown linting for documentation

### DIFF
--- a/.docstyle.rb
+++ b/.docstyle.rb
@@ -1,0 +1,22 @@
+# Style configuration for Hendrix documentation files.
+#
+# For details on how to configure, see [markdownlint docs][1].
+#
+# For explanation of the rules themselves, see [markdownlint's RULES.md][2]
+#
+# [1]: https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md
+# [2]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+
+tag :whitespace
+tag :headers
+tag :ul
+tag :indentation
+tag :bullet
+
+rule "ul-indent", indent: 4
+
+rule "ul-style", style: :dash
+rule "no-duplicate-header", allow_different_nesting: true
+rule "line-length", :line_length => 120
+
+exclude_rule 'MD026'            # Trailing punctuation in header

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,2 @@
+style ".docstyle.rb"
+ignore_front_matter true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/markdownlint/markdownlint
+  rev: e31711c0db57df9b350fbaeaae6de745972f3e66
+  hooks:
+  - id: markdownlint_docker
+    name: Markdown linting

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ install : $(TAR)
 		--eval "(package-install-file \"$(TAR)\")"
 
 
+test-static:
+	pre-commit run --all-files
+
 test : $(SRCS)
 	${CASK} clean-elc
 	${CASK} exec ert-runner --reporter ert+duration

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,6 @@ example one can use the following configuration:
         kubernetes-redraw-frequency 3600))
 ```
 
-
 [Cask]: https://github.com/cask/cask
 [COPYING]: ./COPYING
 [Evil]: https://github.com/emacs-evil/evil

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 ---
-title: Changelog
 hide:
   - navigation
 ---
+# Changelog
 
 All notable changes to this project will be documented here.
 
@@ -17,83 +17,83 @@ versioning][semver].
 
 ### Changed
 
--   New flag `--timestamps` support added for logs command.
-    ([#270](https://github.com/kubernetes-el/kubernetes-el/pull/270))
--   New overview for persistent volume claims.
-    ([#223](https://github.com/kubernetes-el/kubernetes-el/pull/223))
--   Added a new interactive function, `kubernetes-contexts-rename`, for
-    renaming contexts.
-    ([#231](https://github.com/kubernetes-el/kubernetes-el/pull/231))
--   Added a new transient prefix, `kubernetes-context`, for acting on
-    kubectl contexts, e.g. switching, renaming, etc.
-    ([#231](https://github.com/kubernetes-el/kubernetes-el/pull/231))
--   Quitting via \`Q\` from the overview or any `kubernetes-mode` buffer
-    now terminates all in-flight background processes.
-    ([#244](https://github.com/kubernetes-el/kubernetes-el/pull/244))
--   The overview for configmaps now includes a new section to show a
-    (truncated) view of the data.
-    ([#245](https://github.com/kubernetes-el/kubernetes-el/pull/245))
--   Added mapping for E to enable entity editing in evil mode.
-    ([#246](https://github.com/kubernetes-el/kubernetes-el/pull/246)).
--   Added ability to enable and disable [`kubectl` proxies][kubectl proxy] via
-    `P P`, with status display in the overview. ([#252](https://github.com/kubernetes-el/kubernetes-el/pull/252))
--   `kubernetes-overview` now returns an error if `kubectl` or
-    `kubernetes-kubectl-executable` is not found on PATH.
+- New flag `--timestamps` support added for logs command.
+  ([#270](https://github.com/kubernetes-el/kubernetes-el/pull/270))
+- New overview for persistent volume claims.
+  ([#223](https://github.com/kubernetes-el/kubernetes-el/pull/223))
+- Added a new interactive function, `kubernetes-contexts-rename`, for
+  renaming contexts.
+  ([#231](https://github.com/kubernetes-el/kubernetes-el/pull/231))
+- Added a new transient prefix, `kubernetes-context`, for acting on
+  kubectl contexts, e.g. switching, renaming, etc.
+  ([#231](https://github.com/kubernetes-el/kubernetes-el/pull/231))
+- Quitting via \`Q\` from the overview or any `kubernetes-mode` buffer
+  now terminates all in-flight background processes.
+  ([#244](https://github.com/kubernetes-el/kubernetes-el/pull/244))
+- The overview for configmaps now includes a new section to show a
+  (truncated) view of the data.
+  ([#245](https://github.com/kubernetes-el/kubernetes-el/pull/245))
+- Added mapping for E to enable entity editing in evil mode.
+  ([#246](https://github.com/kubernetes-el/kubernetes-el/pull/246)).
+- Added ability to enable and disable [`kubectl` proxies][kubectl proxy] via
+  `P P`, with status display in the overview. ([#252](https://github.com/kubernetes-el/kubernetes-el/pull/252))
+- `kubernetes-overview` now returns an error if `kubectl` or
+  `kubernetes-kubectl-executable` is not found on PATH.
 
 [kubectl proxy]: https://kubernetes.io/docs/tasks/extend-kubernetes/http-proxy-access-api/
 
 ### Refinements
 
--   We've taken a big step towards [support for custom
-    resources](https://github.com/kubernetes-el/kubernetes-el/issues/69),
-    overhauling the process-tracking module – how `kubernetes-el` keeps
-    track of the various `kubectl` processes that it spins up – to be
-    resource agnostic
-    ([#234](https://github.com/kubernetes-el/kubernetes-el/issues/234)).
-    This removes another section of the codebase that historically has
-    had to be updated for every new resource that `kubernetes-el` wants
-    to "support," allowing it to accommodate any and all resources. See:
-    [#237](https://github.com/kubernetes-el/kubernetes-el/pull/237);
-    [#238](https://github.com/kubernetes-el/kubernetes-el/pull/238).
+- We've taken a big step towards [support for custom
+  resources](https://github.com/kubernetes-el/kubernetes-el/issues/69),
+  overhauling the process-tracking module – how `kubernetes-el` keeps
+  track of the various `kubectl` processes that it spins up – to be
+  resource agnostic
+  ([#234](https://github.com/kubernetes-el/kubernetes-el/issues/234)).
+  This removes another section of the codebase that historically has
+  had to be updated for every new resource that `kubernetes-el` wants
+  to "support," allowing it to accommodate any and all resources. See:
+  [#237](https://github.com/kubernetes-el/kubernetes-el/pull/237);
+  [#238](https://github.com/kubernetes-el/kubernetes-el/pull/238).
 
 ### Fixed
 
--   Kubernetes tramp was not respecting set namespace as there are
-    limitations to what we can pass to `tramp-login-args`
-    ([#264](https://github.com/kubernetes-el/kubernetes-el/issues/264)).
-    The fix adds one more step to update the `kubectl` configuration.
+- Kubernetes tramp was not respecting set namespace as there are
+  limitations to what we can pass to `tramp-login-args`
+  ([#264](https://github.com/kubernetes-el/kubernetes-el/issues/264)).
+  The fix adds one more step to update the `kubectl` configuration.
 
 ## 0.17.0
 
 ### Changed
 
--   Explicitly disable the `Exec into container using vterm` suffix of
-    the `kubernetes-exec` transient if `vterm` is not installed
-    ([#209](https://github.com/kubernetes-el/kubernetes-el/pull/209))
+- Explicitly disable the `Exec into container using vterm` suffix of
+  the `kubernetes-exec` transient if `vterm` is not installed
+  ([#209](https://github.com/kubernetes-el/kubernetes-el/pull/209))
 
 ### Fixed
 
--   Some of the migrated transients from 0.16.0 were incomplete; we
-    catch some (hopefully all of) the stragglers in this release. Thanks
-    @noorul for the follow-through here.
+- Some of the migrated transients from 0.16.0 were incomplete; we
+  catch some (hopefully all of) the stragglers in this release. Thanks
+  @noorul for the follow-through here.
 
--   Fixed a bug in Ingress display.
-    ([#214](https://github.com/kubernetes-el/kubernetes-el/pull/214))
+- Fixed a bug in Ingress display.
+  ([#214](https://github.com/kubernetes-el/kubernetes-el/pull/214))
 
 ## 0.16.0
 
 ### Changed
 
--   Ability to find files in pods via `tramp`
-    ([#167](https://github.com/kubernetes-el/kubernetes-el/pull/167))
--   Ability to exec into pods via
-    [vterm](https://github.com/akermu/emacs-libvterm)
-    ([#169](https://github.com/kubernetes-el/kubernetes-el/pull/169))
--   Ability to edit resources
-    ([#186](https://github.com/kubernetes-el/kubernetes-el/pull/186))
--   Migrate several popups from the defunct \`magit-popup\` to
-    \`transient\`
-    ([#190](https://github.com/kubernetes-el/kubernetes-el/pull/190),
-    [#193](https://github.com/kubernetes-el/kubernetes-el/pull/193),
-    [#198](https://github.com/kubernetes-el/kubernetes-el/pull/198),
-    etc.)
+- Ability to find files in pods via `tramp`
+  ([#167](https://github.com/kubernetes-el/kubernetes-el/pull/167))
+- Ability to exec into pods via
+  [vterm](https://github.com/akermu/emacs-libvterm)
+  ([#169](https://github.com/kubernetes-el/kubernetes-el/pull/169))
+- Ability to edit resources
+  ([#186](https://github.com/kubernetes-el/kubernetes-el/pull/186))
+- Migrate several popups from the defunct \`magit-popup\` to
+  \`transient\`
+  ([#190](https://github.com/kubernetes-el/kubernetes-el/pull/190),
+  [#193](https://github.com/kubernetes-el/kubernetes-el/pull/193),
+  [#198](https://github.com/kubernetes-el/kubernetes-el/pull/198),
+  etc.)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,8 +1,9 @@
 ---
-title: Contributing
 hide:
   - navigation
 ---
+
+# Contributing
 
 Hello there, intrepid contributor! Please see the [home page](index.md)
 for basic information about this project.
@@ -31,23 +32,30 @@ your `kubectl` version.
 
 For code changes, please follow the following guidelines.
 
--   Create a GitHub issue to track your work
--   Fork the repository on GitHub
--   Create a feature branch for your PR
--   Take the time to write good commit messages;
-    [here](https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/)
-    are some practical tips.
--   Run tests and make sure they all pass before submitting your PR.
--   If your contribution is a user-facing change, please add an entry to
-    `CHANGELOG.org` in the `Unreleased` section detailing it. See
-    [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) for an
-    overview of this process.
+- Create a GitHub issue to track your work
+- Fork the repository on GitHub
+- Create a feature branch for your PR
+- Take the time to write good commit messages;
+  [here](https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/)
+  are some practical tips.
+- Run tests and make sure they all pass before submitting your PR.
+- If your contribution is a user-facing change, please add an entry to
+  `CHANGELOG.org` in the `Unreleased` section detailing it. See
+  [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) for an
+  overview of this process.
 
 ## Development setup
 
-You will need some third-party tools to build this project. Emacs 25+,
-GNU Make and [Cask](https://github.com/cask/cask) are the most
-important.
+### Dependencies
+
+You will need:
+
+- GNU Make;
+- [Cask](https://github.com/cask/cask);
+- [pre-commit](https://pre-commit.com).
+
+All of these should be installable via Homebrew if you're developing on a Mac
+machine.
 
 You do not need `kubectl` installed in order to run tests, but you do
 need it to run the package inside Emacs.
@@ -77,11 +85,11 @@ should pass.
 Below are some general notes to help make sense of this beast. The main
 points to understand are:
 
--   This package implements a state manager
--   A timer is used to fetch information from Kubernetes and update the
-    state
--   Another timer is used to compile the state into a representation of
-    the overview buffer, which is then interpreted.
+- This package implements a state manager
+- A timer is used to fetch information from Kubernetes and update the
+  state
+- Another timer is used to compile the state into a representation of
+  the overview buffer, which is then interpreted.
 
 The separation of state from rendering improves testability, and makes
 it easier to develop view components that can be reused throughout the
@@ -141,9 +149,9 @@ how objects should be rendered in the UI.
 
 Rendering the overview buffer is divided into two stages:
 
-1.  Take the current state and compile an AST of the desired changes
-2.  Erase the buffer and interpret the AST to execute the changes
-    ([here](kubernetes.el::;;%20Render%20AST%20Interpreter)).
+1. Take the current state and compile an AST of the desired changes
+2. Erase the buffer and interpret the AST to execute the changes
+   ([here](kubernetes.el::;;%20Render%20AST%20Interpreter)).
 
 Future optimizations could include dirty checking to only update certain
 parts of the buffer.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,6 +1,4 @@
----
-title: Getting Started
----
+# Getting Started
 
 ## About This Package
 
@@ -19,7 +17,7 @@ typing. :smile:
     your Kubernetes journey, this documentation will do little to help you in
     that regard; we recommend looking elsewhere for general Kubernetes resources first.
 
-!!! tip 
+!!! tip
 
     `kubernetes-el` is secretly a wrapper around `kubectl`. Don't tell anyone.
 
@@ -76,15 +74,15 @@ To start the package, use the entry-point command `kubernetes-overview`.
 M-x kubernetes-overview
 ```
 
-!!! tip 
+!!! tip
 
     You could consider defining a more concise alias for this command. For
     example, the following would allow you to enter the package via `M-x k8s`.
 
     ```emacs-lisp
-    (fset 'k8s 'kubernetes-overview) 
+    (fset 'k8s 'kubernetes-overview)
     ```
-    
+
 You'll enter the Overview pane. This is where you'll likely spend the majority
 of your time with `kubernetes-el` and where the majority of your interactions
 will take place.

--- a/docs/getting-started/tutorials/0-feature-overview.md
+++ b/docs/getting-started/tutorials/0-feature-overview.md
@@ -1,5 +1,3 @@
----
-title: Feature Overview
----
+# Feature Overview
 
 TODO.

--- a/docs/getting-started/tutorials/index.md
+++ b/docs/getting-started/tutorials/index.md
@@ -1,5 +1,3 @@
----
-title: Tutorials
----
+# Tutorials
 
 TODO.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,8 +1,9 @@
 ---
-title: How-To Guide
 hide:
   - navigation
 ---
+
+# How-To Guide
 
 !!! tip inline end
 
@@ -25,7 +26,7 @@ comprehensive) overview of all that is possible with the package.
 | Keybinding | Interactive function                        |
 |:-----------|:--------------------------------------------|
 | `Q`        | `M-x kubernetes-kill-buffers-and-processes` |
-    
+
 `kubernetes-kill-buffers-and-processes` (`Q`) will kill all buffers
 associated with `kubernetes-el`, as well as terminate all associated
 background processes, e.g. those for querying resources.
@@ -45,10 +46,10 @@ background processes, e.g. those for querying resources.
 !!! missing "Not Yet Implemented"
 
     `kubernetes-el` is currently set up to only work with core resource kinds,
-    and a limited subset of those at that. 
-    
+    and a limited subset of those at that.
+
     Work is currently in-progress to implement support for CRDs; see [issue #69][issue #69].
-    
+
 ### Changing namespace
 
 | Keybinding | Interactive function           |
@@ -86,7 +87,7 @@ server.
 === "Enabled"
 
     ![Overview buffer showing an enabled proxy server](./img/proxy-enabled.png)
-    
+
 === "Disabled"
 
     ![Overview buffer showing a disabled proxy server](./img/proxy-disabled.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
 ---
-title: kubernetes-el
 hide:
   - navigation
 ---
+
+# kubernetes-el
 
 Manage your Kubernetes clusters with Emacs.
 
@@ -26,7 +27,7 @@ With `kubernetes-el`, you can:
 
 ## Development Roadmap
 
-The project is actively being developed. 
+The project is actively being developed.
 
 For known work items, see our [Issues page][issues].
 
@@ -59,7 +60,7 @@ processes, see our [Discussions page][discussions].
 
     More explicit guarantees around Kubernetes compatibility is in the
     works. See [discussion #236][] for details.
-    
+
 We have no guarantees around Kubernetes server compatibility currently. Please
 report any issues to us that you encounter with specific versions.
 
@@ -69,7 +70,7 @@ report any issues to us that you encounter with specific versions.
 
     More explicit guarantees around Kubernetes compatibility is in the
     works. See [discussion #236][] for details.
-    
+
 We have no guarantees around `kubectl` compatibility currently. Please report
 any issues to us that you encounter with specific versions.
 


### PR DESCRIPTION
This PR introduces [Markdownlint](https://github.com/markdownlint/markdownlint)
to ensure the cleanliness of our growing documentation. It integrates it with
[pre-commit](https://pre-commit.com) to allow contributors to ensure that
linting passes even before committing or pushing a PR.

Markdown linting can also be run via `make test-static`.