### PR TITLE
Docs: Refine and reorganize

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,3 @@
----
-hide:
-  - navigation
----
 # Changelog
 
 All notable changes to this project will be documented here.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -168,4 +168,4 @@ The chart below shows the dependencies between features, excluding
 `kubernetes-state`, `kubernets-props` and `kubernetes-modes` which are
 direct dependencies of many modules.
 
-![](assets/project-deps.png)
+![](../assets/project-deps.png)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -35,18 +35,51 @@ This package is available on the [MELPA][] package repository. See the
 instructions there for how to configure Emacs to pull packages from MELPA.
 
 Once you've set that up, use your preferred method of configuring and installing
-packages. If you use [use-package][], the forms below will get you started.
+packages.
 
-```elisp
-(use-package kubernetes
-  :ensure t
-  :commands (kubernetes-overview))
+=== "use-package"
 
-;; If you want to pull in the Evil compatibility package.
-(use-package kubernetes-evil
-  :ensure t
-  :after kubernetes)
-```
+    ```emacs-lisp
+    (use-package kubernetes)
+    ```
+
+=== "straight.el"
+
+    ```emacs-lisp
+    (straight-use-package 'kubernetes)
+    ```
+
+    Or, if you use `straight.el` with `use-package`:
+
+    ```emacs-lisp
+    (use-package kubernetes
+      :straight t)
+    ```
+
+If you'd like to pull in the Evil compatibility package, install the `kubernetes-evil` package as well.
+
+=== "use-package"
+
+    ```elisp
+    (use-package kubernetes-evil
+      :ensure t
+      :after kubernetes)
+    ```
+
+=== "straight.el"
+
+    ```emacs-lisp
+    (straight-use-package 'kubernetes)
+    (straight-use-package 'kubernetes-evil)
+    ```
+
+    Or, if you use `straight.el` with `use-package`:
+
+    ```emacs-lisp
+    (use-package kubernetes-evil
+      :straight t
+      :after kubernetes)
+    ```
 
 Otherwise, you can install the packages with `M-x package-install`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ hide:
 
 # kubernetes-el
 
-Manage your Kubernetes clusters with Emacs.
+![Screenshot of Kubernetes Emacs client](./assets/screenshot.png){ width=60%; height=60%; align="right" }
 
-![Screenshot of Kubernetes Emacs client](./assets/screenshot.png)
+Manage your Kubernetes clusters with Emacs.
 
 ## Feature Overview
 
@@ -25,7 +25,34 @@ With `kubernetes-el`, you can:
 
 [kubectl proxy]: https://kubernetes.io/docs/tasks/extend-kubernetes/http-proxy-access-api/
 
-## Development Roadmap
+## Getting Started
+
+=== "use-package"
+
+    ```emacs-lisp
+    (use-package kubernetes)
+    ```
+
+=== "straight.el"
+
+    ```emacs-lisp
+    (straight-use-package 'kubernetes)
+    ```
+
+    Or, if you use `straight.el` with `use-package`:
+
+    ```emacs-lisp
+    (use-package kubernetes
+      :straight t)
+    ```
+
+Once you've installed, head over to [Getting Started](./getting-started/index.md) for more details.
+
+## About these docs
+
+These docs are structured roughly around the [Diátaxis](https://diataxis.fr/) documentation framework.
+
+## Development roadmap
 
 The project is actively being developed.
 
@@ -34,49 +61,9 @@ For known work items, see our [Issues page][issues].
 For discussions about higher-level direction of the project and development
 processes, see our [Discussions page][discussions].
 
-## Compatibility
-
-### Key
-
-| Definition                                   | Icon                       |
-|----------------------------------------------|:--------------------------:|
-| Fully supported                              | :octicons-check-circle-24: |
-| Tested against, but not officially supported | :octicons-circle-24:       |
-| Unsupported                                  | :octicons-x-circle-24:     |
-
-### Emacs
-
-| Version | Compatibility              |
-|:--------|:---------------------------|
-| 25.x    | :octicons-check-circle-24: |
-| 26.x    | :octicons-check-circle-24: |
-| 27.x    | :octicons-check-circle-24: |
-| 28.x    | :octicons-circle-24:       |
-| 29.x    | :octicons-x-circle-24:     |
-
-### Kubernetes Servers
-
-!!! note
-
-    More explicit guarantees around Kubernetes compatibility is in the
-    works. See [discussion #236][] for details.
-
-We have no guarantees around Kubernetes server compatibility currently. Please
-report any issues to us that you encounter with specific versions.
-
-### `kubectl`
-
-!!! note
-
-    More explicit guarantees around Kubernetes compatibility is in the
-    works. See [discussion #236][] for details.
-
-We have no guarantees around `kubectl` compatibility currently. Please report
-any issues to us that you encounter with specific versions.
-
 ## Contributing
 
-Yes please! 😻 See [Contributing](contributing.md) for details.
+Yes please! 😻 See [Contributing](contributing/index.md) for details.
 
 [COPYING]: ./COPYING
 [Evil]: https://github.com/emacs-evil/evil

--- a/docs/references/compatibility.md
+++ b/docs/references/compatibility.md
@@ -1,0 +1,39 @@
+# Compatibility
+
+## Key
+
+| Definition                                   | Icon                       |
+|----------------------------------------------|:--------------------------:|
+| Fully supported                              | :octicons-check-circle-24: |
+| Tested against, but not officially supported | :octicons-circle-24:       |
+| Unsupported                                  | :octicons-x-circle-24:     |
+
+## Emacs
+
+| Version | Compatibility              |
+|:--------|:---------------------------|
+| 25.x    | :octicons-check-circle-24: |
+| 26.x    | :octicons-check-circle-24: |
+| 27.x    | :octicons-check-circle-24: |
+| 28.x    | :octicons-circle-24:       |
+| 29.x    | :octicons-x-circle-24:     |
+
+## Kubernetes Servers
+
+!!! note
+
+    More explicit guarantees around Kubernetes compatibility is in the
+    works. See [discussion #236][] for details.
+
+We have no guarantees around Kubernetes server compatibility currently. Please
+report any issues to us that you encounter with specific versions.
+
+## `kubectl`
+
+!!! note
+
+    More explicit guarantees around Kubernetes compatibility is in the
+    works. See [discussion #236][] for details.
+
+We have no guarantees around `kubectl` compatibility currently. Please report
+any issues to us that you encounter with specific versions.

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -1,0 +1,4 @@
+# References
+
+These pages contain technical descriptions of the underlying mechanisms of the `kubernetes-el` package. Chances are, in
+day-to-day usage, you will rarely if ever need the contents of these pages.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -9,14 +9,18 @@ repo_url: https://github.com/kubernetes-el/kubernetes-el
 
 nav:
   - Home: index.md
-  - Getting Started: 
+  - Getting Started:
       - getting-started/index.md
       - Tutorials:
-        - getting-started/tutorials/index.md
-        - Feature Overview: getting-started/tutorials/0-feature-overview.md
+          - getting-started/tutorials/index.md
+          - Feature Overview: getting-started/tutorials/0-feature-overview.md
   - How-To: how-to.md
-  - Changelog: CHANGELOG.md
-  - Contributing: contributing.md
+  - References:
+      - references/index.md
+      - Changelog: CHANGELOG.md
+      - Compatibility: references/compatibility.md
+  - Contributors Guide:
+      - contributing/index.md
 
 theme:
   name: material
@@ -31,11 +35,12 @@ theme:
 markdown_extensions:
   - abbr
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - smarty
   - tables
   - meta


### PR DESCRIPTION
This PR makes the following documentation refinements:
- Move version compatibility information to a new References section;
- Take advantage of richer formatting for installation instructions;
- Call out the documentation's adherance to the [Diataxis] framework.

[Diataxis]: https://diataxis.fr/