### PR TITLE
CI: Test against Emacs 28.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,10 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 25.2
           - 25.3
-          - 26.1
-          - 26.2
           - 26.3
-          - 27.1
           - 27.2
+          - 28.1
         include:
           - emacs_version: snapshot
             ignore_error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
-  hooks:
-  - id: check-merge-conflict
-  - id: trailing-whitespace
 - repo: https://github.com/markdownlint/markdownlint
   rev: e31711c0db57df9b350fbaeaae6de745972f3e66
   hooks:

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,8 @@ processes, see our [Discussions page][discussions].
 | 25.x    | :octicons-check-circle-24: |
 | 26.x    | :octicons-check-circle-24: |
 | 27.x    | :octicons-check-circle-24: |
-| 28.x    | :octicons-circle-24:       |
-| 29.x    | :octicons-x-circle-24:     |
+| 28.x    | :octicons-check-circle-24: |
+| 29.x    | :octicons-circle-24:       |
 
 ### Kubernetes Servers
 


### PR DESCRIPTION
We also remove redundant minor versions of back versions, e.g. `26.1`.