### PR TITLE
Remove custom string truncate function; use `s-truncate`

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -2,6 +2,8 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 's)
+
 (require 'kubernetes-ast)
 (require 'kubernetes-contexts)
 (require 'kubernetes-core)
@@ -206,7 +208,7 @@ what to copy."
         (setq first-line (buffer-substring (line-beginning-position) (line-end-position)))
         (while (search-forward "\n" nil t)
           (setq n-lines (1+ n-lines))))
-      (let ((ellipsized (kubernetes-utils-ellipsize first-line 70)))
+      (let ((ellipsized (s-truncate 70 first-line)))
         (if (< 1 n-lines)
             (message "Copied %s lines, starting with: %s" n-lines ellipsized)
           (message "Copied: %s" ellipsized))))))

--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-loading-container)
@@ -29,8 +30,8 @@
             (cl-destructuring-bind (key . val) pair
               `(key-value
                 16
-                ,(kubernetes-utils-ellipsize (symbol-name key) 12)
-                ,(kubernetes-utils-ellipsize val 18))))
+                ,(s-truncate 12 (symbol-name key))
+                ,(s-truncate 18 val))))
           data)))))
 
 (kubernetes-ast-define-component configmap-detail (configmap)
@@ -51,7 +52,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+                         (format (pop list-fmt) (s-truncate 43 name))
                          " "
                          ;; Data
                          (propertize (format (pop list-fmt) (seq-length data)) 'face 'kubernetes-dimmed)

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-kubectl)
 (require 'kubernetes-modes)
@@ -65,7 +66,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+                         (format (pop list-fmt) (s-truncate 43 name))
                          " "
                          ;; Replicas (current/desired)
                          (let ((next (pop list-fmt))

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-loading-container)
@@ -37,20 +38,11 @@
            ingress)
           (line `(line ,(concat
                          ;; Name
-                         (format "%-45s " (kubernetes-utils-ellipsize name 43))
-
+                         (format "%-45s " (s-truncate 43 name))
                          ;; Hosts
-                         (format "%-25s "
-                                 (kubernetes-utils-ellipsize
-                                  (mapconcat (-partial 'alist-get 'host) ingress-rules ", ")
-                                  23))
-
+                         (format "%-25s " (s-truncate 23 (mapconcat (-partial 'alist-get 'host) ingress-rules ", ")))
                          ;; Address
-                         (format "%20s "
-                                 (kubernetes-utils-ellipsize
-                                  (mapconcat (-partial 'alist-get 'ip) ingress-lb-list ", ")
-                                  18))
-
+                         (format "%20s " (s-truncate 18 (mapconcat (-partial 'alist-get 'ip) ingress-lb-list ", ")))
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))
                            (propertize (format "%10s" (kubernetes-utils-time-diff-string start current-time))

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-kubectl)
@@ -66,7 +67,7 @@
           (list-fmt (split-string fmt))
           (line (concat
                  ;; Name
-                 (let ((name-str (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))))
+                 (let ((name-str (format (pop list-fmt) (s-truncate 43 name))))
                    (cond
                     ((and completion-time (< 0 successful))
                      (propertize name-str 'face 'kubernetes-dimmed))

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -4,6 +4,7 @@
 
 (require 'dash)
 (require 'seq)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-loading-container)
@@ -50,10 +51,10 @@
           (str
            (concat
             ;; Name
-            (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+            (format (pop list-fmt) (s-truncate 43 name))
             " "
             ;; Status
-            (let ((s (kubernetes-utils-ellipsize type 10)))
+            (let ((s (s-truncate 10 type)))
               (format (pop list-fmt)
                       (if (string-match-p "running" type)
                           (propertize s 'face 'kubernetes-dimmed)
@@ -61,7 +62,8 @@
             " "
             ;; Roles
             (format (pop list-fmt)
-                    (kubernetes-utils-ellipsize
+                    (s-truncate
+                     8
                      (or
                       (seq-some (lambda (x)
                                   (when (string-match
@@ -69,8 +71,7 @@
                                          x)
                                     (match-string 1 x)))
                                 (mapcar (lambda (x) (symbol-name (car x))) labels))
-                      "<none>")
-                     8))
+                      "<none>")))
             " "
             ;; Age
             (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp creationTimestamp))))
@@ -79,7 +80,7 @@
             " "
             ;; Version
             (format (pop list-fmt)
-                    (propertize (kubernetes-utils-ellipsize kubeProxyVersion 8)
+                    (propertize (s-truncate 8 kubeProxyVersion)
                                 'face 'kubernetes-dimmed))))
           (str (cond
                 ((string-match-p "ready" type) str)

--- a/kubernetes-persistentvolumeclaims.el
+++ b/kubernetes-persistentvolumeclaims.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-loading-container)
@@ -38,7 +39,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 21))
+                         (format (pop list-fmt) (s-truncate 21 name))
                          " "
                          ;; Phase
                          (propertize (format (pop list-fmt) phase) 'face 'kubernetes-dimmed)
@@ -47,7 +48,7 @@
                          (propertize (format (pop list-fmt) capacity) 'face 'kubernetes-dimmed)
                          " "
                          ;; Storage Class
-                         (propertize (format (pop list-fmt) (kubernetes-utils-ellipsize storage-class 12)) 'face 'kubernetes-dimmed)
+                         (propertize (format (pop list-fmt) (s-truncate 12 storage-class)) 'face 'kubernetes-dimmed)
                          " "
                          ;; Age
                          (let ((start (apply #'encode-time (kubernetes-utils-parse-utc-timestamp created-time))))

--- a/kubernetes-pod-line.el
+++ b/kubernetes-pod-line.el
@@ -2,6 +2,8 @@
 ;;; Commentary:
 ;;; Code:
 
+(require 's)
+
 (require 'kubernetes-ast)
 (require 'kubernetes-state)
 (require 'kubernetes-utils)
@@ -32,7 +34,7 @@
             (t
              'warning)))
           (line
-           (concat (propertize (format "%-11s " (kubernetes-utils-ellipsize pod-state 11)) 'face state-face)
+           (concat (propertize (format "%-11s " (s-truncate 11 pod-state)) 'face state-face)
                    name)))
 
     `(section (,(intern (kubernetes-state-resource-name pod)) t)

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 (require 'seq)
 
 (require 'kubernetes-ast)
@@ -68,10 +69,10 @@
           (str
            (concat
             ;; Name
-            (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+            (format (pop list-fmt) (s-truncate 43 name))
             " "
             ;; Status
-            (let ((s (format (pop list-fmt) (kubernetes-utils-ellipsize pod-state 10))))
+            (let ((s (format (pop list-fmt) (s-truncate 10 pod-state))))
               (if (equal pod-state "Running") (propertize s 'face 'kubernetes-dimmed) s))
             " "
             ;; Ready

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-loading-container)
@@ -35,7 +36,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+                         (format (pop list-fmt) (s-truncate 43 name))
                          " "
                          ;; Data
                          (propertize (format (pop list-fmt) (seq-length data)) 'face 'kubernetes-dimmed)

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-ast)
 (require 'kubernetes-kubectl)
@@ -66,7 +67,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+                         (format (pop list-fmt) (s-truncate 43 name))
                          " "
                          ;; Internal IP
                          (propertize (format (pop list-fmt) internal-ip) 'face 'kubernetes-dimmed)

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 'kubernetes-kubectl)
 (require 'kubernetes-modes)
@@ -65,7 +66,7 @@
           (list-fmt (split-string fmt))
           (line `(line ,(concat
                          ;; Name
-                         (format (pop list-fmt) (kubernetes-utils-ellipsize name 43))
+                         (format (pop list-fmt) (s-truncate 43 name))
                          " "
                          ;; Replicas (current/desired)
                          (let ((str (format "%s/%s" current desired))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -68,21 +68,6 @@ initialized."
         (`(:pod-name ,value)
          value)))))
 
-(defun kubernetes-utils-ellipsize (s threshold)
-  "Ellipsize a string S that's longer than THRESHOLD.
-
-If that string spans multiple lines, this is further indicated by
-a backward slash."
-  (let* ((lines (split-string s "\n"))
-         (first-line (car lines))
-         (ellipsized
-          (if (> (length first-line) threshold)
-              (concat (substring first-line 0 (1- threshold)) "...")
-            first-line)))
-    (if (> (length lines) 1)
-        (concat ellipsized (propertize " \\" 'face 'kubernetes-dimmed))
-      ellipsized)))
-
 (defun kubernetes-utils-parse-utc-timestamp (timestamp)
   "Parse TIMESTAMP string from the API into the representation used by Emacs."
   (let ((parsed (parse-time-string (replace-regexp-in-string "Z" "" (replace-regexp-in-string "T" " " timestamp)))))

--- a/test/kubernetes-configmaps-test.el
+++ b/test/kubernetes-configmaps-test.el
@@ -80,10 +80,10 @@ Configmaps (3)
     Namespace:  example-ns
     Created:    2017-03-12T11:10:30Z
     Data: (4)
-      test.trunca...: value
-      test.key2:      this value spans \\
-      test.key3:      longer value that...
-      test.key4:      longer value that... \\
+      test.trun...:   value
+      test.key2:      this value span...
+      test.key3:      longer value th...
+      test.key4:      longer value th...
 
 
 "))

--- a/test/kubernetes-ingress-test.el
+++ b/test/kubernetes-ingress-test.el
@@ -63,7 +63,7 @@ Ingress (0)
 
 Ingress (4)
   Name                                          Hosts                                  Address        Age
-  clojurescript-ingress                         domain.example.io         3.10.144.54, 3.10...        -2y
+  clojurescript-ingress                         domain.example.io           3.10.144.54, 3....        -2y
     Namespace:  default
     Created:    2019-11-13T14:51:00Z
 
@@ -75,7 +75,7 @@ Ingress (4)
     Namespace:  default
     Created:    2018-06-10T11:43:41Z
 
-  example-ingress                               myminikube.info, mylar... 192.168.99.100, 1...        29d
+  example-ingress                               myminikube.info, myl...     192.168.99.100,...        29d
     Namespace:  default
     Created:    2018-06-10T11:43:41Z
 


### PR DESCRIPTION
The `kubernetes-utils-ellipsize` is **basically** made redundant by
`s-truncate`, so for simplicity's sake we use that instead.

This results in a slight functionality change. Namely, the former
appends `//` for multi-line string inputs, whereas the latter does
not. Preserving this behavior does not seem particularly valuable, so we
opt not to do so here.