### PR TITLE
Add Brewfile for development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ kubernetes-autoloads.el
 # Undo-tree save-files
 *.~undo-tree
 /dist
-/assets/project-deps.dot
+docs/assets/project-deps.dot
+
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew "cask"
+brew "graphviz"
+brew "pre-commit"

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -48,20 +48,17 @@ For code changes, please follow the following guidelines.
 
 ### Dependencies
 
-You will need:
+See `Brewfile` for the project's non-Elisp dependencies. If you're developing on a Mac machine, you can install like so
+from the project root:
+```bash
+$ brew bundle
+```
 
-- GNU Make;
-- [Cask](https://github.com/cask/cask);
-- [pre-commit](https://pre-commit.com).
+If you're developing on a Linux machine, install these dependencies manually.
 
-All of these should be installable via Homebrew if you're developing on a Mac
-machine.
+You do not need `kubectl` installed in order to run tests, but you do need it to run the package inside Emacs.
 
-You do not need `kubectl` installed in order to run tests, but you do
-need it to run the package inside Emacs.
-
-If you want to contribute code changes, you should fork the repository.
-Otherwise clone the main repo.
+If you want to contribute code changes, you should fork the repository.  Otherwise clone the main repo.
 
 === "Forked"
 


### PR DESCRIPTION
As of now, package development has at minimum the following non-Emacs dependencies:
- Cask;
- Graphviz, for `dot`;
- Pre-commit.

As a potential contributor, it is unwieldy and cumbersome to have to discover
these either just-in-time or from a list in the contributors' guide that can
easily go stale.

This PR provides a Brewfile enumerating these dependencies such that new
contributors can onboard simply with:
```bash
$ brew bundle
```