### PR TITLE
Implement all-contributors spec

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,208 @@
+{
+  "projectName": "kubernetes-el",
+  "projectOwner": "kubernetes-el",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "docs/CONTRIBUTORS.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "chrisbarrett",
+      "name": "Chris Barrett",
+      "avatar_url": "https://avatars.githubusercontent.com/u/836504?v=4",
+      "profile": "https://github.com/chrisbarrett",
+      "contributions": [
+        "original author",
+        "question",
+        "code",
+        "design",
+        "doc",
+        "ideas",
+        "review"
+      ]
+    },
+    {
+      "login": "jinnovation",
+      "name": "Jonathan Jin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1932579?v=4",
+      "profile": "https://jonathanj.in/",
+      "contributions": [
+        "maintenance",
+        "code",
+        "doc",
+        "ideas",
+        "projectManagement",
+        "review"
+      ]
+    },
+    {
+      "login": "noorul",
+      "name": "Noorul Islam K M",
+      "avatar_url": "https://avatars.githubusercontent.com/u/155376?v=4",
+      "profile": "http://www.noorul.com/",
+      "contributions": [
+        "maintenance",
+        "question",
+        "code",
+        "ideas",
+        "design"
+      ]
+    },
+    {
+      "login": "dickmao",
+      "name": "dickmao",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7578770?v=4",
+      "profile": "https://github.com/dickmao",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ageekymonk",
+      "name": "ramz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/271647?v=4",
+      "profile": "https://blog.ageekymonk.com/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "olymk2",
+      "name": "Oliver Marks",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1034950?v=4",
+      "profile": "https://mastodon.social/@olymk2",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Walheimat",
+      "name": "Krister",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12915439?v=4",
+      "profile": "https://github.com/Walheimat",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "darth10",
+      "name": "Akhil Wali",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1171466?v=4",
+      "profile": "https://darth10.github.io/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "novasharper",
+      "name": "Patrick Long",
+      "avatar_url": "https://avatars.githubusercontent.com/u/757966?v=4",
+      "profile": "https://github.com/novasharper",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "egh",
+      "name": "Erik Hetzner",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22718?v=4",
+      "profile": "http://www.e6h.org/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "fritzgrabo",
+      "name": "Fritz Grabo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/592734?v=4",
+      "profile": "https://github.com/fritzgrabo",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "zaks",
+      "name": "Sławomir Żak",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1446409?v=4",
+      "profile": "https://github.com/zaks",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "cwhatley",
+      "name": "Chris Whatley",
+      "avatar_url": "https://avatars.githubusercontent.com/u/573757?v=4",
+      "profile": "https://github.com/cwhatley",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "fbergroth",
+      "name": "Fredrik Bergroth",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1211003?v=4",
+      "profile": "https://github.com/fbergroth",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "khapota",
+      "name": "Khapota",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2603892?v=4",
+      "profile": "https://github.com/khapota",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "peterbecich",
+      "name": "Peter Becich",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6315338?v=4",
+      "profile": "https://www.linkedin.com/in/peterbecich/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "lcaballero",
+      "name": "Lucas Caballero",
+      "avatar_url": "https://avatars.githubusercontent.com/u/251297?v=4",
+      "profile": "https://github.com/lcaballero",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "syohex",
+      "name": "Shohei YOSHIDA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/554281?v=4",
+      "profile": "https://syohex.org/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "jypma",
+      "name": "Jan Ypma",
+      "avatar_url": "https://avatars.githubusercontent.com/u/483519?v=4",
+      "profile": "https://github.com/jypma",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "types": {
+    "original author": {
+      "symbol": "🛠",
+      "description": "Original Author",
+      "link": "[<%= symbol %>](\"<%= description %>\"),"
+    }
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/CONTRIBUTORS.md linguist-generated=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@ repos:
   hooks:
   - id: markdownlint_docker
     name: Markdown linting
+    exclude: |
+      (?x)^(
+          docs/CONTRIBUTORS.md
+      )$

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -1,0 +1,42 @@
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/chrisbarrett"><img src="https://avatars.githubusercontent.com/u/836504?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Barrett</b></sub></a><br /><a href="[🛠]("Original Author")," title="Original Author">🛠</a> <a href="#question-chrisbarrett" title="Answering Questions">💬</a> <a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=chrisbarrett" title="Code">💻</a> <a href="#design-chrisbarrett" title="Design">🎨</a> <a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=chrisbarrett" title="Documentation">📖</a> <a href="#ideas-chrisbarrett" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/kubernetes-el/kubernetes-el/pulls?q=is%3Apr+reviewed-by%3Achrisbarrett" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://jonathanj.in/"><img src="https://avatars.githubusercontent.com/u/1932579?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jonathan Jin</b></sub></a><br /><a href="#maintenance-jinnovation" title="Maintenance">🚧</a> <a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=jinnovation" title="Code">💻</a> <a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=jinnovation" title="Documentation">📖</a> <a href="#ideas-jinnovation" title="Ideas, Planning, & Feedback">🤔</a> <a href="#projectManagement-jinnovation" title="Project Management">📆</a> <a href="https://github.com/kubernetes-el/kubernetes-el/pulls?q=is%3Apr+reviewed-by%3Ajinnovation" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="http://www.noorul.com/"><img src="https://avatars.githubusercontent.com/u/155376?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Noorul Islam K M</b></sub></a><br /><a href="#maintenance-noorul" title="Maintenance">🚧</a> <a href="#question-noorul" title="Answering Questions">💬</a> <a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=noorul" title="Code">💻</a> <a href="#ideas-noorul" title="Ideas, Planning, & Feedback">🤔</a> <a href="#design-noorul" title="Design">🎨</a></td>
+    <td align="center"><a href="https://github.com/dickmao"><img src="https://avatars.githubusercontent.com/u/7578770?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dickmao</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=dickmao" title="Code">💻</a></td>
+    <td align="center"><a href="https://blog.ageekymonk.com/"><img src="https://avatars.githubusercontent.com/u/271647?v=4?s=100" width="100px;" alt=""/><br /><sub><b>ramz</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=ageekymonk" title="Code">💻</a></td>
+    <td align="center"><a href="https://mastodon.social/@olymk2"><img src="https://avatars.githubusercontent.com/u/1034950?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Oliver Marks</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=olymk2" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Walheimat"><img src="https://avatars.githubusercontent.com/u/12915439?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Krister</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=Walheimat" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://darth10.github.io/"><img src="https://avatars.githubusercontent.com/u/1171466?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Akhil Wali</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=darth10" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/novasharper"><img src="https://avatars.githubusercontent.com/u/757966?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Patrick Long</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=novasharper" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.e6h.org/"><img src="https://avatars.githubusercontent.com/u/22718?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Erik Hetzner</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=egh" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/fritzgrabo"><img src="https://avatars.githubusercontent.com/u/592734?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Fritz Grabo</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=fritzgrabo" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/zaks"><img src="https://avatars.githubusercontent.com/u/1446409?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sławomir Żak</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=zaks" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/cwhatley"><img src="https://avatars.githubusercontent.com/u/573757?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Whatley</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=cwhatley" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/fbergroth"><img src="https://avatars.githubusercontent.com/u/1211003?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Fredrik Bergroth</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=fbergroth" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/khapota"><img src="https://avatars.githubusercontent.com/u/2603892?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Khapota</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=khapota" title="Code">💻</a></td>
+    <td align="center"><a href="https://www.linkedin.com/in/peterbecich/"><img src="https://avatars.githubusercontent.com/u/6315338?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Peter Becich</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=peterbecich" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/lcaballero"><img src="https://avatars.githubusercontent.com/u/251297?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Lucas Caballero</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=lcaballero" title="Code">💻</a></td>
+    <td align="center"><a href="https://syohex.org/"><img src="https://avatars.githubusercontent.com/u/554281?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Shohei YOSHIDA</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=syohex" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jypma"><img src="https://avatars.githubusercontent.com/u/483519?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jan Ypma</b></sub></a><br /><a href="https://github.com/kubernetes-el/kubernetes-el/commits?author=jypma" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -43,6 +43,10 @@ For code changes, please follow the following guidelines.
   `CHANGELOG.org` in the `Unreleased` section detailing it. See
   [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) for an
   overview of this process.
+- Add yourself to the contributors list by commenting something like the following in your PR: `@all-contributors please
+  add @<username> for <code/documentation/etc.>`. See [@all-contributors bot
+  documentation](https://allcontributors.org/docs/en/bot/usage) for more details. See `.all-contributorsrc` for examples
+  of contribution "types."
 
 ## Development setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,9 +61,7 @@ For known work items, see our [Issues page][issues].
 For discussions about higher-level direction of the project and development
 processes, see our [Discussions page][discussions].
 
-## Contributing
-
-Yes please! 😻 See [Contributing](contributing/index.md) for details.
+--8<-- "docs/CONTRIBUTORS.md"
 
 [COPYING]: ./COPYING
 [Evil]: https://github.com/emacs-evil/evil

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -37,7 +37,8 @@ markdown_extensions:
   - admonition
   - attr_list
   - pymdownx.details
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
This PR implements the [all-contributors spec](https://allcontributors.org) to
visibly acknowledge and celebrate all past contributors and their work. It
will be accompanied by installation of the corresponding
[bot](https://allcontributors.org/docs/en/bot/overview) to allow us to update
the contributors table directly from within PRs and the like.