### PR TITLE
Remove strict dependency pin on Emacs 25.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ versioning][semver].
 
 ## Upcoming
 
+### Changed
+
+- Removed strict dependency pin on Emacs 25.1
+
 ## 0.18.0
 
 ### Changed

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -19,8 +19,7 @@ relating to the bug or feature you're interested in. Do your best here!
 
 ### Bug reports
 
-Make sure you're using the latest release of the package, and are using
-Emacs 25.
+Make sure you're using the latest release of the package.
 
 If no ticket exists yet, you can write a new issue. Provide reproduction
 steps if you can, as well as your Emacs version and basic OS info.

--- a/kubernetes.el
+++ b/kubernetes.el
@@ -9,7 +9,7 @@
 
 ;; Version: 0.18.0
 ;; Homepage: https://github.com/kubernetes-el/kubernetes-el
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (request "0.3.2") (s "1.12.0") (transient "0.3.0"))
+;; Package-Requires: ((dash "2.12.0") (magit-section "3.1.1") (magit-popup "2.13.0") (with-editor "3.0.4") (request "0.3.2") (s "1.12.0") (transient "0.3.0"))
 ;; Keywords: kubernetes
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
We test on multiple versions of Emacs now, so this pin no longer makes sense.