### PR TITLE
Fix message on switching namespace to properly show new namespace

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ versioning][semver].
 
 ## Upcoming
 
+### Fixed
+
+- Fixed bug where log message on changing namespace did not properly reflect the selected namespace.
+
 ## 0.18.0
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ versioning][semver].
 
 ### Fixed
 
-- Fixed bug where log message on changing namespace did not properly reflect the selected namespace.
+- Fixed bug where log message on changing namespace did not properly reflect the selected namespace. (#297)
 
 ## 0.18.0
 

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -435,15 +435,15 @@ STATE is the current application state."
   (kubernetes-state-update-current-namespace ns)
   (kubernetes-kubectl-config-set-current-namespace (kubernetes-state)
                                                    (lambda (_)
-                                                     (message "Updated current context `%s' namespace to `%s.'"
+                                                     (kubernetes--info "Updated current context `%s' namespace to `%s.'"
                                                               (alist-get 'name (kubernetes-state-current-context state))
-                                                              (kubernetes-state--get state 'current-namespace)))
+                                                              ns))
                                                    (lambda (buf)
                                                      (let ((s (with-current-buffer buf (buffer-string))))
-                                                       (message "Unable to set namespace `%s' for current context `%s'."
-                                                                (kubernetes-state--get state 'current-namespace)
-                                                                (alist-get 'name (kubernetes-state-current-context state))
-                                                       (message s)))))
+                                                       (kubernetes--error "Unable to set namespace `%s' for current context `%s'."
+                                                                ns
+                                                                (alist-get 'name (kubernetes-state-current-context state)))
+                                                       (kubernetes--message s))))
 
   (kubernetes-state-update-overview-sections (kubernetes-state-overview-sections state))
 


### PR DESCRIPTION
The namespace-change callback messages as currently implemented display the current namespace rather than the post-change namespace.