### PR TITLE
Enable discovery of API groups from cluster

### DIFF
--- a/kubernetes-process.el
+++ b/kubernetes-process.el
@@ -156,7 +156,7 @@ If there is already a process recorded in the ledger, return that
     (oset ledger proxy nil)))
 
 (cl-defmacro kubernetes--with-proxy ((&key cleanup) &rest body)
-  "Start a Kubernetes proxy server and executo BODY.
+  "Start a Kubernetes proxy server and execute BODY.
 
 If CLEANUP is non-nil, terminate the proxy process immediately after BODY."
   ;; TODO: Refactor `get-proxy-process' to return the ported process record object rather than the raw process itself

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -25,19 +25,6 @@ not already active.  See `kubernetes-proxy'."
                                    :parser 'json-read))))))
     (--map (alist-get 'name it) (alist-get 'groups api-group-list))))
 
-(defun kubernetes--preferred-version-for (group-name)
-  "Query for the preferred version of the GROUP-NAME.
-
-This function will error if a proxy server is not already active.
-See `kubernetes-proxy'."
-  (kubernetes--require-proxy
-   (-let* ((url (format "%s/apis/%s"
-                        (base-url (oref kubernetes--global-process-ledger proxy))
-                        group-name))
-           ((&alist 'preferredVersion (&alist 'version version))
-            (request-response-data (kubernetes--request-option url :parser 'json-read))))
-     version)))
-
 (provide 'kubernetes-resources)
 
 ;;; kubernetes-resources.el ends here

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -1,0 +1,45 @@
+;;; kubernetes-resources.el --- Discovering and reasoning about Kubernetes resources -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'json)
+(require 'request)
+
+(require 'kubernetes-core)
+(require 'kubernetes-process)
+
+(defun kubernetes--get-all-groups (&optional api-group-list)
+  "Retrieve all API groups from the API-GROUP-LIST.
+
+API-GROUP-LIST should be an alist representation of a APIGroupList resource.
+
+If API-GROUP-LIST is not provided, this function will attempt to
+query the cluster via proxy.  See `kubernetes-proxy'."
+  (-when-let* ((api-group-list (or
+                                api-group-list
+                                (progn
+                                  ;; TODO: Refactor `get-proxy-process' to return the ported process record object
+                                  ;; rather than the raw process itself
+                                  (get-proxy-process kubernetes--global-process-ledger)
+                                  (request-response-data
+                                   (kubernetes--request-option
+                                    (format "%s/apis" (base-url (oref kubernetes--global-process-ledger proxy)))
+                                    :parser 'json-read)))))
+               (groups (--map (alist-get 'name it)
+                              (alist-get 'groups api-group-list))))
+    ;; TODO: Define a with-proxy-process macro that can take care of spinup and teardown
+    (kill-proxy-process kubernetes--global-process-ledger)
+    groups))
+
+(defun kubernetes--get-all-kinds ()
+  "Retrieve all resource kinds present on the current cluster.
+
+Does nothing and prints a non-fatal error message if there is not
+already an active kubectl proxy.  See `kubernetes-proxy'."
+  (when (not (and (proxy-active-p kubernetes--global-process-ledger)
+                (proxy-ready-p kubernetes--global-process-ledger)))
+      (kubernetes--error "Kubectl proxy not active; start with `kubernetes-proxy' first")))
+
+(provide 'kubernetes-resources)
+
+;;; kubernetes-resources.el ends here

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -22,10 +22,8 @@ not already active.  See `kubernetes-proxy'."
                                  (request-response-data
                                   (kubernetes--request-option
                                    (format "%s/apis" (base-url (oref kubernetes--global-process-ledger proxy)))
-                                   :parser 'json-read)))))
-               (groups (--map (alist-get 'name it)
-                              (alist-get 'groups api-group-list))))
-    groups))
+                                   :parser 'json-read))))))
+    (--map (alist-get 'name it) (alist-get 'groups api-group-list))))
 
 (defun kubernetes--preferred-version-for (group-name)
   "Query for the preferred version of the GROUP-NAME.

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -31,15 +31,6 @@ query the cluster via proxy.  See `kubernetes-proxy'."
     (kill-proxy-process kubernetes--global-process-ledger)
     groups))
 
-(defun kubernetes--get-all-kinds ()
-  "Retrieve all resource kinds present on the current cluster.
-
-Does nothing and prints a non-fatal error message if there is not
-already an active kubectl proxy.  See `kubernetes-proxy'."
-  (when (not (and (proxy-active-p kubernetes--global-process-ledger)
-                (proxy-ready-p kubernetes--global-process-ledger)))
-      (kubernetes--error "Kubectl proxy not active; start with `kubernetes-proxy' first")))
-
 (provide 'kubernetes-resources)
 
 ;;; kubernetes-resources.el ends here

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -33,12 +33,11 @@ not already active.  See `kubernetes-proxy'."
 This function will error if a proxy server is not already active.
 See `kubernetes-proxy'."
   (kubernetes--require-proxy
-   (-let (((&alist 'preferredVersion (&alist 'version version))
-           (request-response-data (kubernetes--request-option
-                                   (format "%s/apis/%s"
-                                           (base-url (oref kubernetes--global-process-ledger proxy))
-                                           group-name)
-                                   :parser 'json-read))))
+   (-let* ((url (format "%s/apis/%s"
+                        (base-url (oref kubernetes--global-process-ledger proxy))
+                        group-name))
+           ((&alist 'preferredVersion (&alist 'version version))
+            (request-response-data (kubernetes--request-option url :parser 'json-read))))
      version)))
 
 (provide 'kubernetes-resources)

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -27,6 +27,20 @@ not already active.  See `kubernetes-proxy'."
                               (alist-get 'groups api-group-list))))
     groups))
 
+(defun kubernetes--preferred-version-for (group-name)
+  "Query for the preferred version of the GROUP-NAME.
+
+This function will error if a proxy server is not already active.
+See `kubernetes-proxy'."
+  (kubernetes--require-proxy
+   (-let (((&alist 'preferredVersion (&alist 'version version))
+           (request-response-data (kubernetes--request-option
+                                   (format "%s/apis/%s"
+                                           (base-url (oref kubernetes--global-process-ledger proxy))
+                                           group-name)
+                                   :parser 'json-read))))
+     version)))
+
 (provide 'kubernetes-resources)
 
 ;;; kubernetes-resources.el ends here

--- a/kubernetes-resources.el
+++ b/kubernetes-resources.el
@@ -9,7 +9,7 @@
 (require 'kubernetes-process)
 
 (defun kubernetes--get-all-groups (&optional api-group-list)
-  "Retrieve all API groups from the API-GROUP-LIST.
+  "Retrieve all API group names from the API-GROUP-LIST.
 
 API-GROUP-LIST should be an alist representation of a APIGroupList resource.
 

--- a/tests/test-resources.el
+++ b/tests/test-resources.el
@@ -1,0 +1,66 @@
+;;; test-resources.el --- Tests for resource discovery -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(load-file "./tests/undercover-init.el")
+
+(require 'kubernetes-resources)
+
+(describe "kubernetes--get-all-groups"
+  (it "gets all the group names from the argument group list"
+    (let ((input (json-read-from-string "{
+  \"kind\": \"APIGroupList\",
+  \"apiVersion\": \"v1\",
+  \"groups\": [
+    {
+      \"name\": \"apiregistration.k8s.io\",
+      \"versions\": [
+        {
+          \"groupVersion\": \"apiregistration.k8s.io/v1\",
+          \"version\": \"v1\"
+        },
+        {
+          \"groupVersion\": \"apiregistration.k8s.io/v1beta1\",
+          \"version\": \"v1beta1\"
+        }
+      ],
+      \"preferredVersion\": {
+        \"groupVersion\": \"apiregistration.k8s.io/v1\",
+        \"version\": \"v1\"
+      }
+    },
+    {
+      \"name\": \"apps\",
+      \"versions\": [
+        {
+          \"groupVersion\": \"apps/v1\",
+          \"version\": \"v1\"
+        }
+      ],
+      \"preferredVersion\": {
+        \"groupVersion\": \"apps/v1\",
+        \"version\": \"v1\"
+      }
+    },
+    {
+      \"name\": \"events.k8s.io\",
+      \"versions\": [
+        {
+          \"groupVersion\": \"events.k8s.io/v1\",
+          \"version\": \"v1\"
+        }
+      ],
+      \"preferredVersion\": {
+        \"groupVersion\": \"events.k8s.io/v1\",
+        \"version\": \"v1\"
+      }
+    }
+  ]
+}")))
+      (expect (kubernetes--get-all-groups input)
+              :to-equal
+              '("apiregistration.k8s.io"
+                "apps"
+                "events.k8s.io")))))
+
+;;; test-resources.el ends here


### PR DESCRIPTION
Contributes to #235.

This PR adds the `kubernetes--get-all-groups` function. This queries the Kubernetes
API via HTTP proxy to discover the API groups present on the cluster.

At the same time, we also introduce a collection of macros to facilitate
interaction with `kubectl` proxy servers, e.g. lifecycle management.

This logic represents the first step to discovering all resource kinds, custom
or otherwise, on the given cluster.