### PR TITLE
Move `kubernetes--save-window-state` macro to top of the file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ versioning][semver].
 
 ## Upcoming
 
+### Fixed
+
+- Fixed an issue where faulty macro definition prevented the overview
+  buffer from successfully refreshing on Emacs 29.x.
+
 ## 0.18.0
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ versioning][semver].
 ### Fixed
 
 - Fixed an issue where faulty macro definition prevented the overview
-  buffer from successfully refreshing on Emacs 29.x.
+  buffer from successfully refreshing on Emacs 29.x. (#303)
 
 ## 0.18.0
 

--- a/kubernetes-core.el
+++ b/kubernetes-core.el
@@ -11,6 +11,23 @@
 
 (defvar kubernetes-state--current-state nil)
 
+(defmacro kubernetes--save-window-state (&rest body)
+  "Restore window state after executing BODY.
+
+This is useful if the buffer is erased and repopulated in BODY,
+in which case `save-excursion' is insufficient to restore the
+window state."
+  `(let ((pos (point))
+         (col (current-column))
+         (window-start-line (window-start))
+         (inhibit-redisplay t))
+     (save-excursion
+       ,@body)
+     (goto-char pos)
+     (move-to-column col)
+     (set-window-start (selected-window) window-start-line)))
+
+
 (defun kubernetes-state ()
   kubernetes-state--current-state)
 
@@ -44,23 +61,6 @@
 
           ;; Force the section at point to highlight.
           (magit-section-update-highlight))))))
-
-
-(defmacro kubernetes--save-window-state (&rest body)
-  "Restore window state after executing BODY.
-
-This is useful if the buffer is erased and repopulated in BODY,
-in which case `save-excursion' is insufficient to restore the
-window state."
-  `(let ((pos (point))
-         (col (current-column))
-         (window-start-line (window-start))
-         (inhibit-redisplay t))
-     (save-excursion
-       ,@body)
-     (goto-char pos)
-     (move-to-column col)
-     (set-window-start (selected-window) window-start-line)))
 
 (defun kubernetes--message (format &rest args)
   "Call `message' with FORMAT and ARGS.


### PR DESCRIPTION
Fixes #295.

Moves `kubernetes--save-window-state` to the top of the file to ensure it's compiled in time.