### PR TITLE
Force erase-buffer

### DIFF
--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -93,6 +93,7 @@ buffer is killed."
 
   (let ((buf (get-buffer-create bufname)))
     (with-current-buffer buf
+      (setq buffer-read-only nil)
       (erase-buffer)
       (buffer-disable-undo)
       (term-mode)


### PR DESCRIPTION
I've customised `kubernetes-clean-up-interactive-exec-buffers` to `nil`. This causes problems for me when I try to run `kubernetes-exec` because it tries to `erase-buffer` on a read-only buffer. I've tried to solve this in the simplest possible way I could.