### PR TITLE
refactor: rename kubernetes-exec-list-buffers to kubernetes-exec-switch-buffers

### DIFF
--- a/kubernetes-exec.el
+++ b/kubernetes-exec.el
@@ -213,7 +213,7 @@ STATE is the current application state."
                                    command-args))))
 
 ;;;###autoload
-(defun kubernetes-exec-list-buffers ()
+(defun kubernetes-exec-switch-buffers ()
   "List all Kubernetes exec buffers and allow selecting one."
   (interactive)
   ;; Use manual filtering instead of seq-filter
@@ -250,7 +250,7 @@ STATE is the current application state."
     ("e" "Exec" kubernetes-exec-into)
     ("v" "Exec into container using vterm" kubernetes-exec-using-vterm
      :inapt-if-not (lambda () (require 'vterm nil 'noerror)))
-    ("l" "List exec buffers" kubernetes-exec-list-buffers)]])
+    ("b" "List exec buffers" kubernetes-exec-switch-buffers)]])
 
 (provide 'kubernetes-exec)
 

--- a/test/kubernetes-exec-test.el
+++ b/test/kubernetes-exec-test.el
@@ -394,9 +394,9 @@
         (when (get-buffer "*test-vterm-buffer*")
           (kill-buffer "*test-vterm-buffer*"))))))
 
-;; Test kubernetes-exec-list-buffers
+;; Test kubernetes-exec-switch-buffers
 (ert-deftest kubernetes-exec-test-list-buffers ()
-  "Test that kubernetes-exec-list-buffers properly lists the exec buffers."
+  "Test that kubernetes-exec-switch-buffers properly lists the exec buffers."
   (let* ((test-buffer1 (generate-new-buffer "*kubernetes exec term: default/pod/nginx*"))
          (test-buffer2 (generate-new-buffer "*kubernetes exec term: production/deployment/api:main*"))
          (test-buffer3 (generate-new-buffer "*kubernetes exec vterm: default/statefulset/db*"))
@@ -434,7 +434,7 @@
             (setq-local kubernetes-exec-command "mysql"))
 
           ;; Run the function
-          (kubernetes-exec-list-buffers)
+          (kubernetes-exec-switch-buffers)
 
           ;; Verify results
           (should (eq selected-buffer test-buffer1)))


### PR DESCRIPTION
This change renames the function to better reflect its actual purpose:
switching between Kubernetes exec buffers rather than just listing them.
The keybinding for this function has also been updated from "l" to "b".