### PR TITLE
fix(kubectl): use consistent resource path format across kubectl interactions

### DIFF
--- a/kubernetes-exec.el
+++ b/kubernetes-exec.el
@@ -114,9 +114,7 @@ ARGS are additional args to pass to kubectl.
 EXEC-COMMAND is the command to run in the container.
 STATE is the current application state."
   ;; Build the command arguments for kubectl exec
-  (let* ((resource-path (if (string= resource-type "pod")
-                          resource-name
-                        (format "%s/%s" resource-type resource-name)))
+  (let* ((resource-path (format "%s/%s" resource-type resource-name))
          (command-args (append (list "exec")
                               (kubernetes-kubectl--flags-from-state state)
                               args

--- a/kubernetes-logs.el
+++ b/kubernetes-logs.el
@@ -118,10 +118,8 @@ STATE is the current application state."
            (transient-args 'kubernetes-logs)
            state)))
 
-  ;; Format the resource in the kubectl resource/name format
-  (let* ((resource-path (if (string= resource-type "pod")
-                            resource-name
-                          (format "%s/%s" resource-type resource-name)))
+  ;; Format the resource in the kubectl resource/name format consistently for all resource types
+  (let* ((resource-path (format "%s/%s" resource-type resource-name))
          ;; Build clean args with namespace at the end
          (namespace-arg (when-let (ns (kubernetes-state--get state 'current-namespace))
                           (list (format "--namespace=%s" ns))))

--- a/test/kubernetes-exec-test.el
+++ b/test/kubernetes-exec-test.el
@@ -231,7 +231,7 @@
               (should (equal (nth 1 pod-cmd) kubernetes-kubectl-executable))
               (let ((args (nth 2 pod-cmd)))
                 (should (equal (nth 0 args) "exec"))
-                (should (member "test-pod" args))
+                (should (member "pod/test-pod" args))
                 (should (member "--namespace=test-namespace" args))
                 (should (member "--" args))
                 (should (member "/bin/bash" args)))
@@ -242,7 +242,7 @@
               (let ((args (nth 2 pod-container-cmd)))
                 (should (equal (nth 0 args) "exec"))
                 (should (member "--container=main-container" args))
-                (should (member "test-pod" args)))
+                (should (member "pod/test-pod" args)))
 
               ;; Verify pod with TTY command
               (should (string-match-p "\\*kubernetes exec term: test-namespace/pod/test-pod\\*"
@@ -250,7 +250,7 @@
               (let ((args (nth 2 pod-tty-cmd)))
                 (should (equal (nth 0 args) "exec"))
                 (should (member "--tty" args))
-                (should (member "test-pod" args)))
+                (should (member "pod/test-pod" args)))
 
               ;; Verify deployment command
               (should (string-match-p "\\*kubernetes exec term: test-namespace/deployment/test-deployment\\*"
@@ -316,7 +316,7 @@
               ;; Verify pod command treats it as a pod
               (should (string-match-p "\\*kubernetes exec term: test-namespace/pod/test-pod\\*"
                                       (nth 0 pod-cmd)))
-              (should (member "test-pod" (nth 2 pod-cmd)))
+              (should (member "pod/test-pod" (nth 2 pod-cmd)))
 
               ;; Verify deployment format is parsed correctly
               (should (string-match-p "\\*kubernetes exec term: test-namespace/deployment/test-deployment\\*"

--- a/test/kubernetes-logs-test.el
+++ b/test/kubernetes-logs-test.el
@@ -222,7 +222,7 @@
               (let ((args (nth 2 pod-cmd)))
                 (should (equal (nth 0 args) "logs"))
                 (should (member "--tail=10" args))
-                (should (member "test-pod" args))
+                (should (member "pod/test-pod" args))
                 (should (member "--namespace=test-namespace" args)))
 
               ;; Verify pod with container command
@@ -230,7 +230,7 @@
               (let ((args (nth 2 pod-container-cmd)))
                 (should (equal (nth 0 args) "logs"))
                 (should (member "--container=main-container" args))
-                (should (member "test-pod" args))
+                (should (member "pod/test-pod" args))
                 (should (member "--namespace=test-namespace" args)))
 
               ;; Verify deployment command


### PR DESCRIPTION
Standardize resource path formatting in both kubernetes-exec.el and kubernetes-logs.el
to consistently use the "resource-type/resource-name" format for all resource types
instead of having special handling for "pod" resources.