### PR TITLE
refactor: extract container name logic into dedicated utility function

### DIFF
--- a/kubernetes-exec.el
+++ b/kubernetes-exec.el
@@ -54,9 +54,7 @@ Returns a cons cell of (type . name)."
   "Generate a buffer name for exec into RESOURCE-TYPE named RESOURCE-NAME with ARGS.
 STATE is the optional current application state for namespace info.
 If USE-VTERM is non-nil, use vterm buffer name format."
-  (let* ((container-arg (seq-find (lambda (arg) (string-prefix-p "--container=" arg)) args))
-         (container-name (when container-arg
-                           (substring container-arg (length "--container="))))
+  (let* ((container-name (kubernetes-utils--extract-container-name-from-args args))
          (container-suffix (if container-name (format ":%s" container-name) ""))
          (namespace (when state (kubernetes-state--get state 'current-namespace)))
          (namespace-prefix (if namespace (format "%s/" namespace) ""))
@@ -144,10 +142,7 @@ STATE is the current application state."
       (setq-local kubernetes-exec-command exec-command)
       (setq-local kubernetes-exec-kubectl-args command-args)
       (setq-local kubernetes-exec-namespace (kubernetes-state--get state 'current-namespace))
-      (setq-local kubernetes-exec-container-name
-                  (let ((container-arg (seq-find (lambda (arg) (string-prefix-p "--container=" arg)) args)))
-                    (when container-arg
-                      (substring container-arg (length "--container="))))))
+      (setq-local kubernetes-exec-container-name (kubernetes-utils--extract-container-name-from-args args)))
 
     ;; Setup process cleanup if needed
     (when (and interactive-tty kubernetes-clean-up-interactive-exec-buffers)

--- a/kubernetes-logs.el
+++ b/kubernetes-logs.el
@@ -27,9 +27,7 @@ fourth %s is replaced with container suffix if specified (including the leading 
 (defun kubernetes-logs--generate-buffer-name (resource-type resource-name args state)
   "Generate a buffer name for logs of RESOURCE-TYPE named RESOURCE-NAME with ARGS in STATE.
 Extracts container name from ARGS if present and includes namespace information."
-  (let* ((container-arg (seq-find (lambda (arg) (string-prefix-p "--container=" arg)) args))
-         (container-name (when container-arg
-                           (substring container-arg (length "--container="))))
+  (let* ((container-name (kubernetes-utils--extract-container-name-from-args args))
          (container-suffix (if container-name (format ":%s" container-name) ""))
          (namespace (kubernetes-state--get state 'current-namespace))
          (namespace-prefix (if namespace (format "%s/" namespace) "")))
@@ -134,10 +132,7 @@ STATE is the current application state."
       (setq-local kubernetes-logs-resource-type resource-type)
       (setq-local kubernetes-logs-resource-name resource-name)
       (setq-local kubernetes-logs-namespace (kubernetes-state--get state 'current-namespace))
-      (setq-local kubernetes-logs-container-name
-                  (let ((container-arg (seq-find (lambda (arg) (string-prefix-p "--container=" arg)) args)))
-                    (when container-arg
-                      (substring container-arg (length "--container=")))))
+      (setq-local kubernetes-logs-container-name (kubernetes-utils--extract-container-name-from-args args))
       ;; Store the complete kubectl command args for direct reuse during refresh
       (setq-local kubernetes-logs-kubectl-args kubectl-args)
       (select-window (display-buffer (current-buffer))))))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -297,6 +297,13 @@ Optional arguments INITIAL-INPUT and HISTORY are passed to `completing-read'."
         (error "No containers available")
       (completing-read (or prompt "Container name: ") container-names nil t initial-input history))))
 
+(defun kubernetes-utils--extract-container-name-from-args (args)
+  "Extract container name from ARGS if present. Return nil if not found or ARGS is nil."
+  (when args
+    (let ((container-arg (seq-find (lambda (arg) (string-prefix-p "--container=" arg)) args)))
+      (when container-arg
+        (substring container-arg (length "--container="))))))
+
 (provide 'kubernetes-utils)
 
 ;;; kubernetes-utils.el ends here

--- a/test/kubernetes-utils-test.el
+++ b/test/kubernetes-utils-test.el
@@ -608,4 +608,13 @@ Point is moved to the position indicated by | in INITIAL-CONTENTS."
       (should (member "sidecar-container" result))
       (should (member "init-container" result)))))
 
+(ert-deftest kubernetes-utils--extract-container-name-from-args-test ()
+  "Test `kubernetes-utils--extract-container-name-from-args` function."
+  (should (equal (kubernetes-utils--extract-container-name-from-args '("--container=my-container"))
+                 "my-container"))
+  (should (equal (kubernetes-utils--extract-container-name-from-args '("--some-other-arg" "--another-arg"))
+                 nil))
+  (should (equal (kubernetes-utils--extract-container-name-from-args nil)
+                 nil)))
+
 ;;; kubernetes-utils-test.el ends here


### PR DESCRIPTION
This refactors duplicated container name extraction logic by creating a
`kubernetes-utils--extract-container-name-from-args` utility function.
The function extracts container names from command line arguments and
is now used consistently in both kubernetes-exec.el and kubernetes-logs.el.