### PR TITLE
build: add .dir-locals.el for Emacs project settings

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((nil . ((projectile-project-compilation-cmd . "make")
+         (projectile-project-test-cmd . "make test"))))


### PR DESCRIPTION
Configures projectile command settings to use "make" for compilation
and "make test" for testing within the Emacs environment.