### PR TITLE
refactor: simplify pod display in overview and improve pod state handling

### DIFF
--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -224,30 +224,14 @@ This function finds pods by matching the statefulset's UID with pod's ownerRefer
        pod-items))))
 
 
-(kubernetes-ast-define-component aggregated-pods (state deployment pods)
-  (-let [(&alist 'spec (&alist
-                        'replicas replicas
-                        'selector (&alist 'matchLabels
-                                          (&alist 'name selector-name
-                                                  'component component-name)
-                                          'matchExpressions match-expressions)))
-         deployment]
+(kubernetes-ast-define-component aggregated-pods (state resource pods)
+  (-let [(&alist 'spec (&alist 'replicas replicas)) resource]
     `(section (pods nil)
               (heading "Pods")
               (indent
-               ,(when selector-name
-                  `(section (selector nil)
-                            (nav-prop (:selector ,selector-name)
-                                      (key-value 12 "Selector" ,(propertize selector-name 'face 'kubernetes-selector)))))
-               ,(when component-name
-                  `(section (component nil)
-                            (nav-prop (:component ,component-name)
-                                      (key-value 12 "Component" ,(propertize component-name 'face 'kubernetes-component)))))
-               ,(when match-expressions
-                  `(section (expressions nil)
-                            (heading "Match Expressions")
-                            (indent ,(kubernetes-yaml-render match-expressions))))
+               ;; Just show replicas count
                (key-value 12 "Replicas" ,(format "%s" (or replicas 1)))
+               ;; Just list the pods directly
                (columnar-loading-container ,(kubernetes-state--get state 'pods) nil
                                            ,@(seq-map (lambda (pod) `(pod-line ,state ,pod)) pods)))
               (padding))))

--- a/test/kubernetes-overview-test.el
+++ b/test/kubernetes-overview-test.el
@@ -64,7 +64,6 @@ Deployments (2)
     Created:    2017-02-17T02:23:30Z
 
     Pods
-      Selector:   example-pod-v3
       Replicas:   1
       Fetching...
 
@@ -76,7 +75,6 @@ Deployments (2)
     Created:    2017-02-22T02:15:36Z
 
     Pods
-      Selector:   deployment-2
       Replicas:   1
       Fetching...
 "))
@@ -109,7 +107,6 @@ Deployments (2)
     Created:    2017-02-17T02:23:30Z
 
     Pods
-      Selector:   example-pod-v3
       Replicas:   1
       Running     example-svc-v3-1603416598-2f9lb
 
@@ -129,7 +126,6 @@ Deployments (2)
     Created:    2017-02-22T02:15:36Z
 
     Pods
-      Selector:   deployment-2
       Replicas:   1
       Running     example-svc-v4-1603416598-2f9lb"))
 


### PR DESCRIPTION
Refactor resource overview component to simplify display by:
- Remove selector, component, and match expressions display
- Improve pod state extraction with safer container state handling
- Simplify aggregated-pods component to work with any resource type
- Remove unused aggregated-deployment-detail component

Fixes #360