### PR TITLE
feat(exec, logs): prioritize manually selected resources over point-based resources

### DIFF
--- a/kubernetes-popups.el
+++ b/kubernetes-popups.el
@@ -56,10 +56,10 @@ If disabling the proxy, ARGS is ignored."
    ["Commands"
     ("d" "Describe" kubernetes-describe)
     ("E" "Edit" kubernetes-edit)
-    ("e" "Exec" kubernetes-exec)
+    ("e" "Exec" kubernetes-exec-reset-and-launch)
     ("f" "File" kubernetes-file)
     ("L" "Labels" kubernetes-labels)
-    ("l" "Logs" kubernetes-logs)
+    ("l" "Logs" kubernetes-logs-reset-and-launch)
     ("P" "Proxy" kubernetes-proxy)
     ("T" "Events" kubernetes-events)
     ("v" "Switch overview view" kubernetes-overview-set-sections)]])

--- a/test/kubernetes-utils-test.el
+++ b/test/kubernetes-utils-test.el
@@ -618,76 +618,40 @@ Point is moved to the position indicated by | in INITIAL-CONTENTS."
                  nil)))
 
 (ert-deftest kubernetes-utils-test-get-resource-name ()
-  "Test kubernetes-utils-get-resource-name function."
+  "Test ~kubernetes-utils-get-resource-name~ function."
   (let ((state '((current-namespace . "default"))))
 
-    ;; Test with singular resource type (should get pluralized)
-    (cl-letf (((symbol-function 'kubernetes-kubectl-await-on-async)
-               (lambda (s fn)
-                 ;; Don't try to inspect fn directly, just return our mock data
-                 '((items . (((metadata . ((name . "pod1"))))
-                            ((metadata . ((name . "pod2")))))))))
-              ((symbol-function 'completing-read)
-               (lambda (prompt choices &rest _)
-                 (should (string= prompt "pod name: "))
-                 (should (equal choices '("pod1" "pod2")))
-                 "pod1")))
-
+    ;; 1. Test with a resource name available via a specific function
+    (cl-letf (((symbol-function 'kubernetes-utils-maybe-pod-name-at-point)
+               (lambda () "pod-at-point")))
       (let ((result (kubernetes-utils-get-resource-name state "pod")))
-        (should (equal result "pod1"))))
+        (should (equal result "pod-at-point"))))
 
-    ;; Test with plural resource type (should stay as-is)
-    (cl-letf (((symbol-function 'kubernetes-kubectl-await-on-async)
-               (lambda (s fn)
-                 '((items . (((metadata . ((name . "deployment1"))))
-                            ((metadata . ((name . "deployment2")))))))))
-              ((symbol-function 'completing-read)
-               (lambda (prompt choices &rest _)
-                 (should (string= prompt "deployments name: "))
-                 (should (equal choices '("deployment1" "deployment2")))
-                 "deployment2")))
+    ;; 2. Test with a resource-specific read function
+    (cl-letf (((symbol-function 'kubernetes-pods--read-name)
+               (lambda (_state) "read-pod-name")))
+      (let ((result (kubernetes-utils-get-resource-name state "pod")))
+        (should (equal result "read-pod-name"))))
 
-      (let ((result (kubernetes-utils-get-resource-name state "deployments")))
-        (should (equal result "deployment2"))))
+    ;; 3. Test with a dynamically constructed function for ~persistentvolumeclaim~
+    (cl-letf (((symbol-function 'kubernetes-utils-maybe-pvc-name-at-point)
+               (lambda () "pvc-at-point")))
+      (let ((result (kubernetes-utils-get-resource-name state "persistentvolumeclaim")))
+        (should (equal result "pvc-at-point"))))
 
-    ;; Test with empty results
-    (cl-letf (((symbol-function 'kubernetes-kubectl-await-on-async)
-               (lambda (s fn)
-                 ;; Return empty items
-                 '((items . ()))))
-              ((symbol-function 'read-string)
-               (lambda (prompt &rest _)
-                 (should (string= prompt "service name: "))
-                 "my-service")))
+    ;; 4. Test with a resource-specific read function for ~persistentvolumeclaim~
+    (cl-letf (((symbol-function 'kubernetes-persistentvolumeclaims--read-name)
+               (lambda (_state) "read-pvc-name")))
+      (let ((result (kubernetes-utils-get-resource-name state "persistentvolumeclaim")))
+        (should (equal result "read-pvc-name"))))
 
+    ;; 5. Test with no specific function or read function available
+    (cl-letf (((symbol-function 'kubernetes-utils-maybe-service-name-at-point)
+               (lambda () nil))
+              ((symbol-function 'kubernetes-services--read-name)
+               (lambda (_state) nil)))
       (let ((result (kubernetes-utils-get-resource-name state "service")))
-        (should (equal result "my-service"))))
-
-    ;; Test with nil resources
-    (cl-letf (((symbol-function 'kubernetes-kubectl-await-on-async)
-               (lambda (s fn)
-                 ;; Return nil (could happen due to error)
-                 nil))
-              ((symbol-function 'read-string)
-               (lambda (prompt &rest _)
-                 (should (string= prompt "job name: "))
-                 "my-job")))
-
-      (let ((result (kubernetes-utils-get-resource-name state "job")))
-        (should (equal result "my-job"))))
-
-    ;; Test with nil items
-    (cl-letf (((symbol-function 'kubernetes-kubectl-await-on-async)
-               (lambda (s fn)
-                 ;; Return response with nil items
-                 '((something-else . "value"))))
-              ((symbol-function 'read-string)
-               (lambda (prompt &rest _)
-                 (should (string= prompt "statefulset name: "))
-                 "my-statefulset")))
-
-      (let ((result (kubernetes-utils-get-resource-name state "statefulset")))
-        (should (equal result "my-statefulset"))))))
+        (should (equal result nil))))))
 
 (ert-deftest kubernetes-utils-test-select-resource ()
   "Test `kubernetes-utils-select-resource' function."


### PR DESCRIPTION
Refactor resource selection logic in `kubernetes-exec` and
`kubernetes-logs` modules to prioritize manually selected resources
over resources at point. Updated corresponding test cases to reflect
the new behavior.