### PR TITLE
ci: drop Emacs 27.2 and add 30.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 27.2
           - 28.2
           - 29.4
+          - 30.2
           - release-snapshot
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}


### PR DESCRIPTION
magit-section has dropped support for Emacs 27