### PR TITLE
test: fix format-seconds compat for Emacs 31 (Bug#75849)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - 29.4
           - 30.2
           - release-snapshot
+          - snapshot
     env:
       EMACS_VERSION: ${{ matrix.emacs_version }}
     steps:
@@ -71,45 +72,3 @@ jobs:
           files: ./coverage/lcov-ert.info,./coverage/lcov-buttercup.info
           fail_ci_if_error: true
           verbose: true
-
-  test-against-emacs-snapshot-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Emacs
-        uses: purcell/setup-emacs@master
-        with:
-          version: "snapshot"
-
-      - name: Setup Python (for Cask)
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-
-      - name: Setup Cask
-        uses: conao3/setup-cask@master
-        with:
-          version: "snapshot"
-
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Install
-        id: install
-        run: |
-          emacs --version
-          cask build --verbose
-          make build
-
-      - name: Test
-        continue-on-error: true
-        id: test
-        if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
-        run: |
-          make test
-
-      - name: Warn if snapshot test failed
-        if: steps.test.outcome == 'failure'
-        run: |
-          echo "### ⚠️ Optional test-against-emacs-snapshot job failed ⚠️" >> "$GITHUB_STEP_SUMMARY"

--- a/test/kubernetes-ingress-test.el
+++ b/test/kubernetes-ingress-test.el
@@ -63,9 +63,9 @@ Ingress (0)
 
 Ingress (4)
   Name                                          Hosts                                  Address        Age
-  clojurescript-ingress                         domain.example.io           3.10.144.54, 3....        -2y
+  clojurescript-ingress                         domain.example.io           3.10.144.54, 3....        -1y
     Namespace:  default
-    Created:    2019-11-13T14:51:00Z
+    Created:    2019-07-10T10:43:00Z
 
   example-ingress                               myminikube.info                 192.168.99.100        29d
     Namespace:  default
@@ -84,7 +84,7 @@ Ingress (4)
 
 (ert-deftest kubernetes-ingress-test--sample-response ()
   (let ((state `((ingress . ,sample-get-ingress-response)
-                 (current-time . ,(date-to-time "2018-07-10 10:43Z")))))
+                 (current-time . ,(date-to-time "2018-07-10T10:43:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-ingress-section state)))

--- a/test/kubernetes-nodes-test.el
+++ b/test/kubernetes-nodes-test.el
@@ -82,7 +82,7 @@ Nodes (1)
 
 (ert-deftest kubernetes-nodes-test--sample-response ()
   (let ((state `((nodes . ,sample-get-nodes-response)
-                 (current-time . ,(date-to-time "2017-04-03 00:00Z")))))
+                 (current-time . ,(date-to-time "2017-04-03T00:00:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-nodes-section state)))
@@ -91,7 +91,7 @@ Nodes (1)
 
 (ert-deftest kubernetes-nodes-test--sample-response-text-properties ()
   (let ((state `((nodes . ,sample-get-nodes-response)
-                 (current-time . ,(date-to-time "2017-04-03 00:00Z")))))
+                 (current-time . ,(date-to-time "2017-04-03T00:00:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-nodes-section state)))

--- a/test/kubernetes-persistentvolumeclaims-test.el
+++ b/test/kubernetes-persistentvolumeclaims-test.el
@@ -76,7 +76,7 @@ Persistent Volume Claims (2)
 
 (ert-deftest kubernetes-persistentvolumeclaims-test--sample-response ()
   (let ((state `((persistentvolumeclaims . ,sample-get-persistentvolumeclaims-response)
-                 (current-time . ,(date-to-time "2021-11-06 00:00Z")))))
+                 (current-time . ,(date-to-time "2021-11-06T00:00:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-persistentvolumeclaims-section state)))

--- a/test/kubernetes-services-test.el
+++ b/test/kubernetes-services-test.el
@@ -85,7 +85,7 @@ Services (2)
 
 (ert-deftest kubernetes-services-test--sample-response ()
   (let ((state `((services . ,sample-get-services-response)
-                 (current-time . ,(date-to-time "2017-04-03 00:00Z")))))
+                 (current-time . ,(date-to-time "2017-04-03T00:00:00Z")))))
     (with-temp-buffer
       (save-excursion (magit-insert-section (root)
                         (draw-services-section state)))

--- a/test/resources/get-ingress-response.json
+++ b/test/resources/get-ingress-response.json
@@ -9,7 +9,7 @@
                     "kubernetes.io/ingress.class": "nginx",
                     "kubernetes.io/tls-acme": "true"
                 },
-                "creationTimestamp": "2019-11-13T14:51:00Z",
+                "creationTimestamp": "2019-07-10T10:43:00Z",
                 "generation": 3,
                 "labels": {
                     "app": "nginx-ingress",

--- a/test/resources/get-nodes-response.json
+++ b/test/resources/get-nodes-response.json
@@ -10,7 +10,7 @@
                     "node.alpha.kubernetes.io/ttl": "0",
                     "volumes.kubernetes.io/controller-managed-attach-detach": "true"
                 },
-                "creationTimestamp": "2019-11-13T15:33:27Z",
+                "creationTimestamp": "2020-04-02T00:00:00Z",
                 "labels": {
                     "beta.kubernetes.io/arch": "amd64",
                     "beta.kubernetes.io/os": "linux",


### PR DESCRIPTION
Emacs commit 6b40dbda6ad changed how format-seconds handles negative
values: old behavior used floor(-N), new uses -floor(N). For non-integer
diffs these can differ by 1 unit.

Fix by choosing fixture timestamps that are exact integer multiples of
31536000s from the test current-time, so both old and new Emacs agree.
Also switch date-to-time calls from "YYYY-MM-DD HH:MMZ" to ISO 8601
"YYYY-MM-DDTHH:MM:SSZ" format to avoid Emacs 31 timezone parsing bug
where the Z suffix was treated as local time instead of UTC.